### PR TITLE
feat: improve favourites feature

### DIFF
--- a/app/src/main/java/com/firdavs/persianliterature/app/navigation/Navigator.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/navigation/Navigator.kt
@@ -21,6 +21,7 @@ import com.firdavs.persianliterature.about_app.ui.AboutAppEntryPoint
 import com.firdavs.persianliterature.app.R
 import com.firdavs.persianliterature.app.ui.MainActivityUiState
 import com.firdavs.persianliterature.author.ui.details.AuthorDetailsEntryPoint
+import com.firdavs.persianliterature.author.ui.favourites.FavouritesEntryPoint
 import com.firdavs.persianliterature.author.ui.list.AuthorsListEntryPoint
 import com.firdavs.persianliterature.author.ui.work_details.WorkDetailsEntryPoint
 import com.firdavs.persianliterature.core.model.Chapter
@@ -70,6 +71,7 @@ fun Navigator(
                     onChapterClick = { chapter ->
                         when (chapter) {
                             Chapter.AboutApp -> backStack.startNewRoot(Route.AboutApp)
+                            Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
                             else -> {}
                         }
                     }
@@ -93,9 +95,23 @@ fun Navigator(
                     onChapterClick = { chapter ->
                         when (chapter) {
                             Chapter.Authors -> backStack.startNewRoot(Route.AuthorsList)
+                            Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
                             else -> {}
                         }
                     }
+                )
+            }
+            entry<Route.Favourites> {
+                FavouritesEntryPoint(
+                    onChapterClick = { chapter ->
+                        when (chapter) {
+                            Chapter.Authors -> backStack.startNewRoot(Route.AuthorsList)
+                            Chapter.AboutApp -> backStack.startNewRoot(Route.AboutApp)
+                            else -> {}
+                        }
+                    },
+                    onAuthorClick = { backStack.next(Route.AuthorDetails(it)) },
+                    onWorkClick = { backStack.next(Route.WorkDetails(it)) }
                 )
             }
         }

--- a/app/src/main/java/com/firdavs/persianliterature/app/navigation/Route.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/navigation/Route.kt
@@ -15,4 +15,7 @@ sealed interface Route : NavKey {
 
     @Serializable
     object AboutApp : Route
+
+    @Serializable
+    object Favourites : Route
 }

--- a/author/src/main/java/com/firdavs/persianliterature/author/db/dao/AuthorsDao.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/dao/AuthorsDao.kt
@@ -22,4 +22,13 @@ interface AuthorsDao {
 
     @Query("SELECT * FROM ${AuthorsDb.AUTHORS} WHERE id = :id")
     fun getByIdFlow(id: String): Flow<AuthorEntity>
+
+    @Query("SELECT * FROM ${AuthorsDb.AUTHORS} WHERE isFavourite = 1")
+    fun getFavouritesFlow(): Flow<List<AuthorEntity>>
+
+    @Query("UPDATE ${AuthorsDb.AUTHORS} SET isFavourite = :isFavourite WHERE id = :id")
+    suspend fun updateFavourite(id: String, isFavourite: Boolean)
+
+    @Query("SELECT id FROM ${AuthorsDb.AUTHORS} WHERE isFavourite = 1")
+    suspend fun getFavouriteIds(): List<String>
 }

--- a/author/src/main/java/com/firdavs/persianliterature/author/db/dao/WorksDao.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/dao/WorksDao.kt
@@ -19,4 +19,13 @@ interface WorksDao {
 
     @Query("SELECT * FROM ${AuthorsDb.WORKS} WHERE id = :id")
     fun getByIdFlow(id: String): Flow<WorkEntity>
+
+    @Query("SELECT * FROM ${AuthorsDb.WORKS} WHERE isFavourite = 1")
+    fun getFavouritesFlow(): Flow<List<WorkEntity>>
+
+    @Query("UPDATE ${AuthorsDb.WORKS} SET isFavourite = :isFavourite WHERE id = :id")
+    suspend fun updateFavourite(id: String, isFavourite: Boolean)
+
+    @Query("SELECT id FROM ${AuthorsDb.WORKS} WHERE isFavourite = 1")
+    suspend fun getFavouriteIds(): List<String>
 }

--- a/author/src/main/java/com/firdavs/persianliterature/author/db/mapper/AuthorsEntityToDomainMapperImpl.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/mapper/AuthorsEntityToDomainMapperImpl.kt
@@ -24,7 +24,8 @@ fun AuthorEntity.toDomain() = Author(
     born = this.born,
     died = this.died,
     place = this.place,
-    bioUrl = this.bioUrl
+    bioUrl = this.bioUrl,
+    isFavourite = this.isFavourite
 )
 
 fun Author.toDb() = AuthorEntity(
@@ -34,5 +35,6 @@ fun Author.toDb() = AuthorEntity(
     born = this.born,
     died = this.died,
     place = this.place,
-    bioUrl = this.bioUrl
+    bioUrl = this.bioUrl,
+    isFavourite = this.isFavourite
 )

--- a/author/src/main/java/com/firdavs/persianliterature/author/db/model/AuthorEntity.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/model/AuthorEntity.kt
@@ -12,5 +12,6 @@ data class AuthorEntity(
     val born: String,
     val died: String,
     val place: String,
-    val bioUrl: String?
+    val bioUrl: String?,
+    val isFavourite: Boolean = false
 )

--- a/author/src/main/java/com/firdavs/persianliterature/author/db/model/WorkEntity.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/model/WorkEntity.kt
@@ -11,7 +11,8 @@ data class WorkEntity(
     val authorId: String,
     val title: String,
     val publishYear: String,
-    val fileUrl: String?
+    val fileUrl: String?,
+    val isFavourite: Boolean = false
 )
 
 fun List<WorkEntity>.toDomain() = map { it.toDomain() }
@@ -21,5 +22,6 @@ fun WorkEntity.toDomain() = Work(
     authorId = authorId,
     title = title,
     publishYear = publishYear,
-    fileUrl = fileUrl
+    fileUrl = fileUrl,
+    isFavourite = isFavourite
 )

--- a/author/src/main/java/com/firdavs/persianliterature/author/di/AuthorModule.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/di/AuthorModule.kt
@@ -7,8 +7,10 @@ import com.firdavs.persianliterature.author.db.dao.WorksDao
 import com.firdavs.persianliterature.author.db.mapper.AuthorsEntityToDomainMapper
 import com.firdavs.persianliterature.author.db.mapper.AuthorsEntityToDomainMapperImpl
 import com.firdavs.persianliterature.author.repository.AuthorRepositoryImpl
+import com.firdavs.persianliterature.author.repository.FavouritesRepositoryImpl
 import com.firdavs.persianliterature.author.repository.WorksRepositoryImpl
 import com.firdavs.persianliterature.author_api.repository.AuthorRepository
+import com.firdavs.persianliterature.author_api.repository.FavouritesRepository
 import com.firdavs.persianliterature.author_api.repository.WorksRepository
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.singleOf
@@ -18,6 +20,7 @@ import org.koin.dsl.module
 val authorModule = module {
     singleOf(::AuthorRepositoryImpl) bind AuthorRepository::class
     singleOf(::WorksRepositoryImpl) bind WorksRepository::class
+    singleOf(::FavouritesRepositoryImpl) bind FavouritesRepository::class
     single<AuthorsDb> {
         Room.databaseBuilder(
             androidContext(),

--- a/author/src/main/java/com/firdavs/persianliterature/author/repository/AuthorRepositoryImpl.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/repository/AuthorRepositoryImpl.kt
@@ -27,7 +27,12 @@ class AuthorRepositoryImpl(
             val authorDto = document.toObject(AuthorDTO::class.java)
             authorDto?.copy(id = document.id)
         }
-        authorsDao.insert(authorsDTO.toDb())
+        // Preserve existing favourite status
+        val existingFavouriteIds = authorsDao.getFavouriteIds().toSet()
+        val authorsWithFavourites = authorsDTO.toDb().map { author ->
+            author.copy(isFavourite = author.id in existingFavouriteIds)
+        }
+        authorsDao.insert(authorsWithFavourites)
     }
 
     override fun getAuthors(): Flow<List<Author>> {

--- a/author/src/main/java/com/firdavs/persianliterature/author/repository/FavouritesRepositoryImpl.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/repository/FavouritesRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.firdavs.persianliterature.author.repository
+
+import com.firdavs.persianliterature.author.db.dao.AuthorsDao
+import com.firdavs.persianliterature.author.db.dao.WorksDao
+import com.firdavs.persianliterature.author.db.mapper.toDomain
+import com.firdavs.persianliterature.author.db.model.toDomain
+import com.firdavs.persianliterature.author_api.model.Author
+import com.firdavs.persianliterature.author_api.model.Work
+import com.firdavs.persianliterature.author_api.repository.FavouritesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class FavouritesRepositoryImpl(
+    private val authorsDao: AuthorsDao,
+    private val worksDao: WorksDao
+) : FavouritesRepository {
+
+    override fun getFavouriteAuthors(): Flow<List<Author>> {
+        return authorsDao.getFavouritesFlow().map { entities ->
+            entities.map { it.toDomain() }
+        }
+    }
+
+    override fun getFavouriteWorks(): Flow<List<Work>> {
+        return worksDao.getFavouritesFlow().map { entities ->
+            entities.toDomain()
+        }
+    }
+
+    override suspend fun toggleAuthorFavourite(id: String, isFavourite: Boolean) {
+        authorsDao.updateFavourite(id, isFavourite)
+    }
+
+    override suspend fun toggleWorkFavourite(id: String, isFavourite: Boolean) {
+        worksDao.updateFavourite(id, isFavourite)
+    }
+}

--- a/author/src/main/java/com/firdavs/persianliterature/author/repository/WorksRepositoryImpl.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/repository/WorksRepositoryImpl.kt
@@ -26,7 +26,12 @@ class WorksRepositoryImpl(
             val workDto = document.toObject(WorkDTO::class.java)
             workDto?.copy(id = document.id)
         }
-        worksDao.insert(worksDTO.toDb())
+        // Preserve existing favourite status
+        val existingFavouriteIds = worksDao.getFavouriteIds().toSet()
+        val worksWithFavourites = worksDTO.toDb().map { work ->
+            work.copy(isFavourite = work.id in existingFavouriteIds)
+        }
+        worksDao.insert(worksWithFavourites)
     }
 
     override fun getWorksByAuthorId(authorId: String): Flow<List<Work>> {

--- a/author_api/src/main/java/com/firdavs/persianliterature/author_api/model/Author.kt
+++ b/author_api/src/main/java/com/firdavs/persianliterature/author_api/model/Author.kt
@@ -7,5 +7,6 @@ data class Author(
     val born: String,
     val died: String,
     val place: String,
-    val bioUrl: String?
+    val bioUrl: String?,
+    val isFavourite: Boolean = false
 )

--- a/author_api/src/main/java/com/firdavs/persianliterature/author_api/model/Work.kt
+++ b/author_api/src/main/java/com/firdavs/persianliterature/author_api/model/Work.kt
@@ -5,5 +5,6 @@ data class Work(
     val authorId: String,
     val title: String,
     val publishYear: String,
-    val fileUrl: String?
+    val fileUrl: String?,
+    val isFavourite: Boolean = false
 )

--- a/author_api/src/main/java/com/firdavs/persianliterature/author_api/repository/FavouritesRepository.kt
+++ b/author_api/src/main/java/com/firdavs/persianliterature/author_api/repository/FavouritesRepository.kt
@@ -1,0 +1,12 @@
+package com.firdavs.persianliterature.author_api.repository
+
+import com.firdavs.persianliterature.author_api.model.Author
+import com.firdavs.persianliterature.author_api.model.Work
+import kotlinx.coroutines.flow.Flow
+
+interface FavouritesRepository {
+    fun getFavouriteAuthors(): Flow<List<Author>>
+    fun getFavouriteWorks(): Flow<List<Work>>
+    suspend fun toggleAuthorFavourite(id: String, isFavourite: Boolean)
+    suspend fun toggleWorkFavourite(id: String, isFavourite: Boolean)
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.DateRange
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -61,7 +63,9 @@ fun AuthorDetailsEntryPoint(
             state = state,
             onWorkClick = onWorkClick,
             onChapterClick = viewModel::onChapterClick,
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onToggleAuthorFavourite = viewModel::onToggleAuthorFavourite,
+            onToggleWorkFavourite = viewModel::onToggleWorkFavourite
         )
     }
 }
@@ -71,7 +75,9 @@ fun AuthorDetailsScreen(
     state: AuthorDetailsUiState,
     onChapterClick: (Chapter) -> Unit,
     onWorkClick: (String) -> Unit,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onToggleAuthorFavourite: (Boolean) -> Unit = {},
+    onToggleWorkFavourite: (String, Boolean) -> Unit = { _, _ -> }
 ) {
     BaseScreen(
         topBar = { drawerState, scope ->
@@ -94,6 +100,33 @@ fun AuthorDetailsScreen(
                     text = stringResource(state.chapter.getStringRes()),
                     textAlign = TextAlign.Center
                 )
+                if (state.chapter == Chapter.Bio) {
+                    state.author?.let { author ->
+                        IconButton(
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd),
+                            onClick = { onToggleAuthorFavourite(!author.isFavourite) }
+                        ) {
+                            Icon(
+                                imageVector = if (author.isFavourite) {
+                                    Icons.Filled.Favorite
+                                } else {
+                                    Icons.Outlined.FavoriteBorder
+                                },
+                                contentDescription = if (author.isFavourite) {
+                                    stringResource(R.string.remove_from_favourites)
+                                } else {
+                                    stringResource(R.string.add_to_favourites)
+                                },
+                                tint = if (author.isFavourite) {
+                                    LocalColors.current.primary
+                                } else {
+                                    LocalColors.current.onPrimary
+                                }
+                            )
+                        }
+                    }
+                }
             }
         },
         mainContent = {
@@ -123,7 +156,8 @@ fun AuthorDetailsScreen(
                             Chapter.Works -> {
                                 WorksChapter(
                                     works = state.works,
-                                    onWorkClick = onWorkClick
+                                    onWorkClick = onWorkClick,
+                                    onToggleWorkFavourite = onToggleWorkFavourite
                                 )
                             }
                         }
@@ -188,7 +222,11 @@ private fun BioChapter(
 }
 
 @Composable
-private fun WorksChapter(works: List<Work>, onWorkClick: (String) -> Unit) {
+private fun WorksChapter(
+    works: List<Work>,
+    onWorkClick: (String) -> Unit,
+    onToggleWorkFavourite: (String, Boolean) -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -210,7 +248,11 @@ private fun WorksChapter(works: List<Work>, onWorkClick: (String) -> Unit) {
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(works) { work ->
-                    WorkItem(work, onWorkClick = onWorkClick)
+                    WorkItem(
+                        work = work,
+                        onWorkClick = onWorkClick,
+                        onToggleFavourite = onToggleWorkFavourite
+                    )
                     HorizontalDivider(
                         modifier = Modifier.padding(horizontal = 16.dp),
                         thickness = 1.dp,
@@ -225,7 +267,8 @@ private fun WorksChapter(works: List<Work>, onWorkClick: (String) -> Unit) {
 @Composable
 private fun WorkItem(
     work: Work,
-    onWorkClick: (String) -> Unit
+    onWorkClick: (String) -> Unit,
+    onToggleFavourite: (String, Boolean) -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -237,12 +280,31 @@ private fun WorkItem(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        H4Text(
-            text = work.title
-        )
-        H5Text(
-            text = stringResource(R.string.published_at, work.publishYear)
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            H4Text(text = work.title)
+            H5Text(text = stringResource(R.string.published_at, work.publishYear))
+        }
+        IconButton(
+            onClick = { onToggleFavourite(work.id, !work.isFavourite) }
+        ) {
+            Icon(
+                imageVector = if (work.isFavourite) {
+                    Icons.Filled.Favorite
+                } else {
+                    Icons.Outlined.FavoriteBorder
+                },
+                contentDescription = if (work.isFavourite) {
+                    stringResource(R.string.remove_from_favourites)
+                } else {
+                    stringResource(R.string.add_to_favourites)
+                },
+                tint = if (work.isFavourite) {
+                    LocalColors.current.primary
+                } else {
+                    LocalColors.current.onPrimary
+                }
+            )
+        }
     }
 }
 

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsScreen.kt
@@ -113,11 +113,7 @@ fun AuthorDetailsScreen(
                                 } else {
                                     Icons.Outlined.FavoriteBorder
                                 },
-                                contentDescription = if (author.isFavourite) {
-                                    stringResource(R.string.remove_from_favourites)
-                                } else {
-                                    stringResource(R.string.add_to_favourites)
-                                },
+                                contentDescription = null,
                                 tint = if (author.isFavourite) {
                                     LocalColors.current.primary
                                 } else {
@@ -293,11 +289,7 @@ private fun WorkItem(
                 } else {
                     Icons.Outlined.FavoriteBorder
                 },
-                contentDescription = if (work.isFavourite) {
-                    stringResource(R.string.remove_from_favourites)
-                } else {
-                    stringResource(R.string.add_to_favourites)
-                },
+                contentDescription = null,
                 tint = if (work.isFavourite) {
                     LocalColors.current.primary
                 } else {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.firdavs.persianliterature.author.ui.mapper.toUi
 import com.firdavs.persianliterature.author_api.repository.AuthorRepository
+import com.firdavs.persianliterature.author_api.repository.FavouritesRepository
 import com.firdavs.persianliterature.author_api.repository.WorksRepository
 import com.firdavs.persianliterature.core.presentation.BaseViewModel
 import com.firdavs.persianliterature.util.coroutines.runWithRetry
@@ -21,7 +22,8 @@ class AuthorDetailsViewModel(
     private val context: Context,
     private val authorRepository: AuthorRepository,
     private val worksRepository: WorksRepository,
-    private val pdfDownloader: PdfDownloader
+    private val pdfDownloader: PdfDownloader,
+    private val favouritesRepository: FavouritesRepository
 ) : BaseViewModel<AuthorDetailsUiState>(AuthorDetailsUiState(null)) {
 
     private val downloadPdfScope = CoroutineScope(Job() + Dispatchers.IO)
@@ -75,6 +77,18 @@ class AuthorDetailsViewModel(
 
     fun onChapterClick(chapter: Chapter) {
         post { it.copy(chapter = chapter) }
+    }
+
+    fun onToggleAuthorFavourite(isFavourite: Boolean) {
+        viewModelScope.launch {
+            favouritesRepository.toggleAuthorFavourite(id, isFavourite)
+        }
+    }
+
+    fun onToggleWorkFavourite(workId: String, isFavourite: Boolean) {
+        viewModelScope.launch {
+            favouritesRepository.toggleWorkFavourite(workId, isFavourite)
+        }
     }
 
     companion object {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/di/Module.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/di/Module.kt
@@ -1,6 +1,7 @@
 package com.firdavs.persianliterature.author.ui.di
 
 import com.firdavs.persianliterature.author.ui.details.AuthorDetailsViewModel
+import com.firdavs.persianliterature.author.ui.favourites.FavouritesViewModel
 import com.firdavs.persianliterature.author.ui.list.AuthorsListViewModel
 import com.firdavs.persianliterature.author.ui.mapper.AuthorUiMapper
 import com.firdavs.persianliterature.author.ui.mapper.AuthorUiMapperImpl
@@ -14,10 +15,12 @@ import org.koin.dsl.module
 
 val authorUiModule = module {
     viewModelOf(::AuthorsListViewModel)
+    viewModelOf(::FavouritesViewModel)
     viewModel {
             (args: Array<Any?>) -> AuthorDetailsViewModel(
         args.first() as String,
         androidContext(),
+        get(),
         get(),
         get(),
         get()
@@ -27,6 +30,7 @@ val authorUiModule = module {
             (args: Array<Any?>) -> WorkDetailsViewModel(
         args.first() as String,
         androidContext(),
+        get(),
         get(),
         get()
     )

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesScreen.kt
@@ -1,0 +1,300 @@
+package com.firdavs.persianliterature.author.ui.favourites
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.outlined.Create
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.firdavs.persianliterature.author.ui.R
+import com.firdavs.persianliterature.author.ui.list.AuthorItem
+import com.firdavs.persianliterature.author.ui.model.AuthorUiModel
+import com.firdavs.persianliterature.author_api.model.Work
+import com.firdavs.persianliterature.core.model.Chapter
+import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
+import com.firdavs.persianliterature.ui.kit.BaseScreen
+import com.firdavs.persianliterature.ui.kit.H3Text
+import com.firdavs.persianliterature.ui.kit.H4Text
+import com.firdavs.persianliterature.ui.kit.H5Text
+import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
+import com.firdavs.persianliterature.ui.kit.theme.LocalColors
+import kotlinx.coroutines.launch
+
+@Composable
+fun FavouritesEntryPoint(
+    onChapterClick: (Chapter) -> Unit,
+    onAuthorClick: (String) -> Unit,
+    onWorkClick: (String) -> Unit
+) {
+    BaseEntryPoint(FavouritesViewModel::class) { state, viewModel ->
+        FavouritesScreen(
+            state = state,
+            onChapterClick = onChapterClick,
+            onTabSelected = viewModel::onTabSelected,
+            onAuthorClick = onAuthorClick,
+            onWorkClick = onWorkClick,
+            onRemoveAuthorFromFavourites = viewModel::onRemoveAuthorFromFavourites,
+            onRemoveWorkFromFavourites = viewModel::onRemoveWorkFromFavourites
+        )
+    }
+}
+
+@Composable
+private fun FavouritesScreen(
+    state: FavouritesUiState,
+    onChapterClick: (Chapter) -> Unit,
+    onTabSelected: (FavouritesTab) -> Unit,
+    onAuthorClick: (String) -> Unit,
+    onWorkClick: (String) -> Unit,
+    onRemoveAuthorFromFavourites: (String) -> Unit,
+    onRemoveWorkFromFavourites: (String) -> Unit
+) {
+    BaseScreen(
+        drawerContent = {
+            DrawerSheet(
+                chapters = state.chapters,
+                onChapterClick = onChapterClick
+            )
+        },
+        topBar = { drawerState, scope ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
+                IconButton(
+                    onClick = { scope.launch { drawerState.open() } }
+                ) {
+                    Icon(Icons.Default.Menu, "Open drawer")
+                }
+                H3Text(
+                    modifier = Modifier
+                        .align(Alignment.Center),
+                    text = stringResource(R.string.favourites),
+                    textAlign = TextAlign.Center
+                )
+            }
+        },
+        mainContent = {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                when (state.selectedTab) {
+                    FavouritesTab.Authors -> {
+                        FavouriteAuthorsContent(
+                            authors = state.favouriteAuthors,
+                            onAuthorClick = onAuthorClick,
+                            onRemoveFromFavourites = onRemoveAuthorFromFavourites
+                        )
+                    }
+                    FavouritesTab.Works -> {
+                        FavouriteWorksContent(
+                            works = state.favouriteWorks,
+                            onWorkClick = onWorkClick,
+                            onRemoveFromFavourites = onRemoveWorkFromFavourites
+                        )
+                    }
+                }
+            }
+        },
+        footerContent = {
+            FavouritesFooter(
+                selectedTab = state.selectedTab,
+                onTabSelected = onTabSelected
+            )
+        }
+    )
+}
+
+@Composable
+private fun FavouriteAuthorsContent(
+    authors: List<AuthorUiModel>,
+    onAuthorClick: (String) -> Unit,
+    onRemoveFromFavourites: (String) -> Unit
+) {
+    if (authors.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            H4Text(
+                text = stringResource(R.string.no_favourite_authors),
+                textAlign = TextAlign.Center
+            )
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(authors) { author ->
+                FavouriteAuthorItem(
+                    author = author,
+                    onAuthorClick = onAuthorClick,
+                    onRemoveFromFavourites = onRemoveFromFavourites
+                )
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    thickness = 1.dp,
+                    color = LocalColors.current.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavouriteAuthorItem(
+    author: AuthorUiModel,
+    onAuthorClick: (String) -> Unit,
+    onRemoveFromFavourites: (String) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onAuthorClick(author.id) },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.weight(1f)) {
+            AuthorItem(author = author, onAuthorClick = onAuthorClick)
+        }
+        IconButton(
+            onClick = { onRemoveFromFavourites(author.id) }
+        ) {
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = "Remove from favourites",
+                tint = LocalColors.current.primary
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavouriteWorksContent(
+    works: List<Work>,
+    onWorkClick: (String) -> Unit,
+    onRemoveFromFavourites: (String) -> Unit
+) {
+    if (works.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            H4Text(
+                text = stringResource(R.string.no_favourite_works),
+                textAlign = TextAlign.Center
+            )
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(works) { work ->
+                FavouriteWorkItem(
+                    work = work,
+                    onWorkClick = onWorkClick,
+                    onRemoveFromFavourites = onRemoveFromFavourites
+                )
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    thickness = 1.dp,
+                    color = LocalColors.current.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavouriteWorkItem(
+    work: Work,
+    onWorkClick: (String) -> Unit,
+    onRemoveFromFavourites: (String) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onWorkClick(work.id) }
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            H4Text(text = work.title)
+            H5Text(text = stringResource(R.string.published_at, work.publishYear))
+        }
+        IconButton(
+            onClick = { onRemoveFromFavourites(work.id) }
+        ) {
+            Icon(
+                imageVector = Icons.Default.Favorite,
+                contentDescription = "Remove from favourites",
+                tint = LocalColors.current.primary
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavouritesFooter(
+    selectedTab: FavouritesTab,
+    onTabSelected: (FavouritesTab) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        IconButton(
+            modifier = Modifier.weight(1f),
+            onClick = { onTabSelected(FavouritesTab.Authors) }
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Person,
+                contentDescription = "Authors",
+                tint = if (selectedTab == FavouritesTab.Authors) {
+                    LocalColors.current.onPrimary
+                } else {
+                    LocalColors.current.onPrimary.copy(alpha = 0.5f)
+                }
+            )
+        }
+        IconButton(
+            modifier = Modifier.weight(1f),
+            onClick = { onTabSelected(FavouritesTab.Works) }
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Create,
+                contentDescription = "Works",
+                tint = if (selectedTab == FavouritesTab.Works) {
+                    LocalColors.current.onPrimary
+                } else {
+                    LocalColors.current.onPrimary.copy(alpha = 0.5f)
+                }
+            )
+        }
+    }
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesUiState.kt
@@ -1,0 +1,21 @@
+package com.firdavs.persianliterature.author.ui.favourites
+
+import com.firdavs.persianliterature.author.ui.model.AuthorUiModel
+import com.firdavs.persianliterature.author_api.model.Work
+import com.firdavs.persianliterature.core.model.Chapter
+import com.firdavs.persianliterature.core.presentation.UiState
+
+data class FavouritesUiState(
+    val favouriteAuthors: List<AuthorUiModel> = emptyList(),
+    val favouriteWorks: List<Work> = emptyList(),
+    val selectedTab: FavouritesTab = FavouritesTab.Authors,
+    val chapters: List<Chapter> = listOf(
+        Chapter.Authors,
+        Chapter.AboutApp,
+        Chapter.Settings
+    )
+) : UiState()
+
+enum class FavouritesTab {
+    Authors, Works
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesViewModel.kt
@@ -1,0 +1,50 @@
+package com.firdavs.persianliterature.author.ui.favourites
+
+import androidx.lifecycle.viewModelScope
+import com.firdavs.persianliterature.author.ui.mapper.AuthorUiMapper
+import com.firdavs.persianliterature.author_api.repository.FavouritesRepository
+import com.firdavs.persianliterature.core.presentation.BaseViewModel
+import kotlinx.coroutines.launch
+
+class FavouritesViewModel(
+    private val favouritesRepository: FavouritesRepository,
+    private val authorUiMapper: AuthorUiMapper
+) : BaseViewModel<FavouritesUiState>(FavouritesUiState()) {
+
+    init {
+        observeFavouriteAuthors()
+        observeFavouriteWorks()
+    }
+
+    private fun observeFavouriteAuthors() {
+        viewModelScope.launch {
+            favouritesRepository.getFavouriteAuthors().collect { authors ->
+                post { it.copy(favouriteAuthors = authorUiMapper.map(authors)) }
+            }
+        }
+    }
+
+    private fun observeFavouriteWorks() {
+        viewModelScope.launch {
+            favouritesRepository.getFavouriteWorks().collect { works ->
+                post { it.copy(favouriteWorks = works) }
+            }
+        }
+    }
+
+    fun onTabSelected(tab: FavouritesTab) {
+        post { it.copy(selectedTab = tab) }
+    }
+
+    fun onRemoveAuthorFromFavourites(authorId: String) {
+        viewModelScope.launch {
+            favouritesRepository.toggleAuthorFavourite(authorId, false)
+        }
+    }
+
+    fun onRemoveWorkFromFavourites(workId: String) {
+        viewModelScope.launch {
+            favouritesRepository.toggleWorkFavourite(workId, false)
+        }
+    }
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
@@ -304,11 +304,7 @@ fun AuthorItem(
                     } else {
                         Icons.Outlined.FavoriteBorder
                     },
-                    contentDescription = if (author.isFavourite) {
-                        stringResource(R.string.remove_from_favourites)
-                    } else {
-                        stringResource(R.string.add_to_favourites)
-                    },
+                    contentDescription = null,
                     tint = if (author.isFavourite) {
                         LocalColors.current.primary
                     } else {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.firdavs.persianliterature.author_api.repository.AuthorRepository
 import com.firdavs.persianliterature.author.ui.mapper.AuthorUiMapper
 import com.firdavs.persianliterature.author.ui.model.AuthorUiModel
+import com.firdavs.persianliterature.author_api.repository.FavouritesRepository
 import com.firdavs.persianliterature.author_api.repository.WorksRepository
 import com.firdavs.persianliterature.core.presentation.BaseViewModel
 import kotlinx.coroutines.launch
@@ -12,7 +13,8 @@ import kotlinx.coroutines.launch
 class AuthorsListViewModel(
     private val authorRepository: AuthorRepository,
     private val authorUiMapper: AuthorUiMapper,
-    private val worksRepository: WorksRepository
+    private val worksRepository: WorksRepository,
+    private val favouritesRepository: FavouritesRepository
 ) :
     BaseViewModel<AuthorsListUiState>(AuthorsListUiState()) {
     init {
@@ -77,6 +79,12 @@ class AuthorsListViewModel(
             author.name.contains(searchQuery, ignoreCase = true)
         }
         post { it.copy(authors = filteredAuthors) }
+    }
+
+    fun onToggleFavourite(authorId: String, isFavourite: Boolean) {
+        viewModelScope.launch {
+            favouritesRepository.toggleAuthorFavourite(authorId, isFavourite)
+        }
     }
 
     companion object {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/mapper/AuthorUiMapperImpl.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/mapper/AuthorUiMapperImpl.kt
@@ -15,5 +15,6 @@ fun Author.toUi() = AuthorUiModel(
     name = this.name,
     born = this.born,
     died = this.died,
-    bioUrl = this.bioUrl
+    bioUrl = this.bioUrl,
+    isFavourite = this.isFavourite
 )

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/model/AuthorUiModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/model/AuthorUiModel.kt
@@ -6,5 +6,6 @@ data class AuthorUiModel(
     val name: String,
     val born: String,
     val died: String,
-    val bioUrl: String? = null
+    val bioUrl: String? = null,
+    val isFavourite: Boolean = false
 )

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,6 +24,7 @@ import com.firdavs.persianliterature.ui.kit.BaseScreen
 import com.firdavs.persianliterature.ui.kit.H2Text
 import com.firdavs.persianliterature.ui.kit.H3Text
 import com.firdavs.persianliterature.ui.kit.H4Text
+import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 import com.rajat.pdfviewer.compose.PdfRendererViewCompose
 import com.rajat.pdfviewer.util.PdfSource
 
@@ -33,7 +36,8 @@ fun WorkDetailsEntryPoint(
     BaseEntryPoint(WorkDetailsViewModel::class, id) { state, viewModel ->
         WorkDetailsScreen(
             state = state,
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onToggleFavourite = viewModel::onToggleFavourite
         )
     }
 }
@@ -41,7 +45,8 @@ fun WorkDetailsEntryPoint(
 @Composable
 fun WorkDetailsScreen(
     state: WorkDetailsUiState,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onToggleFavourite: (Boolean) -> Unit = {}
 ) {
     BaseScreen(
         topBar = { drawerState, scope ->
@@ -64,6 +69,31 @@ fun WorkDetailsScreen(
                     text = state.work?.title ?: "",
                     textAlign = TextAlign.Center
                 )
+                state.work?.let { work ->
+                    IconButton(
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd),
+                        onClick = { onToggleFavourite(!work.isFavourite) }
+                    ) {
+                        Icon(
+                            imageVector = if (work.isFavourite) {
+                                Icons.Filled.Favorite
+                            } else {
+                                Icons.Outlined.FavoriteBorder
+                            },
+                            contentDescription = if (work.isFavourite) {
+                                stringResource(R.string.remove_from_favourites)
+                            } else {
+                                stringResource(R.string.add_to_favourites)
+                            },
+                            tint = if (work.isFavourite) {
+                                LocalColors.current.primary
+                            } else {
+                                LocalColors.current.onPrimary
+                            }
+                        )
+                    }
+                }
             }
         },
         mainContent = {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -81,11 +81,7 @@ fun WorkDetailsScreen(
                             } else {
                                 Icons.Outlined.FavoriteBorder
                             },
-                            contentDescription = if (work.isFavourite) {
-                                stringResource(R.string.remove_from_favourites)
-                            } else {
-                                stringResource(R.string.add_to_favourites)
-                            },
+                            contentDescription = null,
                             tint = if (work.isFavourite) {
                                 LocalColors.current.primary
                             } else {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsViewModel.kt
@@ -3,6 +3,7 @@ package com.firdavs.persianliterature.author.ui.work_details
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.lifecycle.viewModelScope
+import com.firdavs.persianliterature.author_api.repository.FavouritesRepository
 import com.firdavs.persianliterature.author_api.repository.WorksRepository
 import com.firdavs.persianliterature.core.presentation.BaseViewModel
 import com.firdavs.persianliterature.util.coroutines.runWithRetry
@@ -18,7 +19,8 @@ class WorkDetailsViewModel(
     private val id: String,
     private val context: Context,
     private val worksRepository: WorksRepository,
-    private val pdfDownloader: PdfDownloader
+    private val pdfDownloader: PdfDownloader,
+    private val favouritesRepository: FavouritesRepository
 ) : BaseViewModel<WorkDetailsUiState>(WorkDetailsUiState(null)) {
     private val downloadPdfScope = CoroutineScope(Job() + Dispatchers.IO)
 
@@ -58,6 +60,12 @@ class WorkDetailsViewModel(
         pdfDownloader.downloadPdfFile(pdfUrl = url, fileName = fileName) { pdfFile ->
             post { it.copy(isLoading = false) }
             post { it.copy(workFile = pdfFile) }
+        }
+    }
+
+    fun onToggleFavourite(isFavourite: Boolean) {
+        viewModelScope.launch {
+            favouritesRepository.toggleWorkFavourite(id, isFavourite)
         }
     }
 }

--- a/author_ui/src/main/res/values/strings.xml
+++ b/author_ui/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="no_works_found">No works found</string>
     <string name="no_bio_found">No bio found</string>
     <string name="published_at">published at %s</string>
+    <string name="no_favourite_authors">No favourite authors yet</string>
+    <string name="no_favourite_works">No favourite works yet</string>
+    <string name="add_to_favourites">Add to favourites</string>
+    <string name="remove_from_favourites">Remove from favourites</string>
 </resources>

--- a/author_ui/src/main/res/values/strings.xml
+++ b/author_ui/src/main/res/values/strings.xml
@@ -12,6 +12,4 @@
     <string name="published_at">published at %s</string>
     <string name="no_favourite_authors">No favourite authors yet</string>
     <string name="no_favourite_works">No favourite works yet</string>
-    <string name="add_to_favourites">Add to favourites</string>
-    <string name="remove_from_favourites">Remove from favourites</string>
 </resources>


### PR DESCRIPTION
- Change favourite icon color from error to primary across all screens
- Hide favourite icon on topbar when Works tab is selected in AuthorDetailsScreen
- Fix tab icon visibility in FavouritesScreen footer (selected vs unselected states)
- Change Works tab icon to Create (pencil) icon in FavouritesScreen
- Fix favourite state not persisting when navigating between screens
  - Preserve existing favourite IDs when fetching authors/works from Firebase