### PR TITLE
Show all chapters in left bar and disable current chapter

### DIFF
--- a/about_app/src/main/java/com/firdavs/persianliterature/about_app/ui/AboutAppScreen.kt
+++ b/about_app/src/main/java/com/firdavs/persianliterature/about_app/ui/AboutAppScreen.kt
@@ -49,6 +49,7 @@ private fun AboutAppScreen(
         drawerContent = {
             DrawerSheet(
                 chapters = state.chapters,
+                currentChapter = Chapter.AboutApp,
                 onChapterClick = onChapterClick
             )
         },

--- a/about_app/src/main/java/com/firdavs/persianliterature/about_app/ui/AboutAppUiState.kt
+++ b/about_app/src/main/java/com/firdavs/persianliterature/about_app/ui/AboutAppUiState.kt
@@ -5,12 +5,7 @@ import com.firdavs.persianliterature.core.model.Chapter
 import com.firdavs.persianliterature.core.presentation.UiState
 
 data class AboutAppUiState(
-    val chapters: List<Chapter> = listOf(
-        Chapter.Authors,
-        Chapter.AboutApp,
-        Chapter.Favourites,
-        Chapter.Settings
-    ),
+    val chapters: List<Chapter> = Chapter.all,
     val features: List<Int> = listOf(
         R.string.authors_list_with_works,
         R.string.add_favourites,

--- a/about_app/src/main/java/com/firdavs/persianliterature/about_app/ui/AboutAppUiState.kt
+++ b/about_app/src/main/java/com/firdavs/persianliterature/about_app/ui/AboutAppUiState.kt
@@ -7,6 +7,7 @@ import com.firdavs.persianliterature.core.presentation.UiState
 data class AboutAppUiState(
     val chapters: List<Chapter> = listOf(
         Chapter.Authors,
+        Chapter.AboutApp,
         Chapter.Favourites,
         Chapter.Settings
     ),

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesScreen.kt
@@ -72,6 +72,7 @@ private fun FavouritesScreen(
         drawerContent = {
             DrawerSheet(
                 chapters = state.chapters,
+                currentChapter = Chapter.Favourites,
                 onChapterClick = onChapterClick
             )
         },

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesUiState.kt
@@ -12,6 +12,7 @@ data class FavouritesUiState(
     val chapters: List<Chapter> = listOf(
         Chapter.Authors,
         Chapter.AboutApp,
+        Chapter.Favourites,
         Chapter.Settings
     )
 ) : UiState()

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesUiState.kt
@@ -9,12 +9,7 @@ data class FavouritesUiState(
     val favouriteAuthors: List<AuthorUiModel> = emptyList(),
     val favouriteWorks: List<Work> = emptyList(),
     val selectedTab: FavouritesTab = FavouritesTab.Authors,
-    val chapters: List<Chapter> = listOf(
-        Chapter.Authors,
-        Chapter.AboutApp,
-        Chapter.Favourites,
-        Chapter.Settings
-    )
+    val chapters: List<Chapter> = Chapter.all
 ) : UiState()
 
 enum class FavouritesTab {

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
@@ -96,6 +96,7 @@ private fun AuthorsListScreen(
         drawerContent = {
             DrawerSheet(
                 chapters = state.chapters,
+                currentChapter = Chapter.Authors,
                 onChapterClick = onChapterClick
             )
         },

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
@@ -10,6 +10,7 @@ data class AuthorsListUiState(
     val searchQuery: String = "",
     val isLoading: Boolean = true,
     val chapters: List<Chapter> = listOf(
+        Chapter.Authors,
         Chapter.AboutApp,
         Chapter.Favourites,
         Chapter.Settings

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
@@ -9,10 +9,5 @@ data class AuthorsListUiState(
     val isSearchActive: Boolean = false,
     val searchQuery: String = "",
     val isLoading: Boolean = true,
-    val chapters: List<Chapter> = listOf(
-        Chapter.Authors,
-        Chapter.AboutApp,
-        Chapter.Favourites,
-        Chapter.Settings
-    )
+    val chapters: List<Chapter> = Chapter.all
 ) : UiState()

--- a/core/src/main/java/com/firdavs/persianliterature/core/model/Chapter.kt
+++ b/core/src/main/java/com/firdavs/persianliterature/core/model/Chapter.kt
@@ -6,5 +6,9 @@ enum class Chapter(val titleRes: Int) {
     Authors(R.string.authors),
     AboutApp(R.string.about_app),
     Favourites(R.string.favourites),
-    Settings(R.string.settings)
+    Settings(R.string.settings);
+
+    companion object {
+        val all = listOf(Authors, AboutApp, Favourites, Settings)
+    }
 }

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/DrawerSheet.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/DrawerSheet.kt
@@ -37,7 +37,10 @@ fun DrawerSheet(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable(enabled = !isCurrentChapter) { onChapterClick(chapter) }
-                        .background(color = colors.primary, shape = RoundedCornerShape(8.dp))
+                        .background(
+                            color = if (isCurrentChapter) colors.primary.copy(alpha = 0.5f) else colors.primary,
+                            shape = RoundedCornerShape(8.dp)
+                        )
                         .padding(8.dp),
                     res = chapter.titleRes
                 )

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/DrawerSheet.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/DrawerSheet.kt
@@ -19,6 +19,7 @@ import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 @Composable
 fun DrawerSheet(
     chapters: List<Chapter>,
+    currentChapter: Chapter,
     onChapterClick: (Chapter) -> Unit
 ) {
     val colors = LocalColors.current
@@ -31,10 +32,11 @@ fun DrawerSheet(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             items(chapters) { chapter ->
+                val isCurrentChapter = chapter == currentChapter
                 H4Text(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { onChapterClick(chapter) }
+                        .clickable(enabled = !isCurrentChapter) { onChapterClick(chapter) }
                         .background(color = colors.primary, shape = RoundedCornerShape(8.dp))
                         .padding(8.dp),
                     res = chapter.titleRes


### PR DESCRIPTION
Fixes #11

This PR implements the requested changes to the chapter navigation in the left sidebar.

### Changes
- Modified DrawerSheet to accept a `currentChapter` parameter
- All chapters now appear in the left bar on every screen
- The current chapter is disabled (non-clickable) instead of hidden
- Updated all UI states to include the complete chapter list

### Testing
Please verify:
1. All chapters appear in the left sidebar on every root screen
2. The current chapter is visible but not clickable
3. Navigation between chapters works as expected

Generated with [Claude Code](https://claude.ai/code)