### PR TITLE
Change progress bar color to primary and move to ui_kit

### DIFF
--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/details/AuthorDetailsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.DateRange
 import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -45,6 +44,7 @@ import com.firdavs.persianliterature.ui.kit.H2Text
 import com.firdavs.persianliterature.ui.kit.H3Text
 import com.firdavs.persianliterature.ui.kit.H4Text
 import com.firdavs.persianliterature.ui.kit.H5Text
+import com.firdavs.persianliterature.ui.kit.components.ProgressIndicator
 import com.firdavs.persianliterature.ui.kit.theme.AppPreviewTheme
 import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 import com.rajat.pdfviewer.PdfRendererView
@@ -131,7 +131,7 @@ fun AuthorDetailsScreen(
                     .fillMaxSize()
             ) {
                 if (state.isLoading) {
-                    CircularProgressIndicator(
+                    ProgressIndicator(
                         modifier = Modifier
                             .align(Alignment.Center)
                     )
@@ -193,7 +193,7 @@ private fun BioChapter(
         horizontalAlignment = CenterHorizontally
     ) {
         if (isLoadingFile) {
-            CircularProgressIndicator()
+            ProgressIndicator()
             H4Text(text = stringResource(R.string.bio_loading))
         } else {
             bioFile?.let { bioFile ->

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -50,6 +49,7 @@ import com.firdavs.persianliterature.ui.kit.BaseScreen
 import com.firdavs.persianliterature.ui.kit.H3Text
 import com.firdavs.persianliterature.ui.kit.T1Text
 import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
+import com.firdavs.persianliterature.ui.kit.components.ProgressIndicator
 import com.firdavs.persianliterature.ui.kit.theme.AppPreviewTheme
 import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 import com.firdavs.persianliterature.ui.kit.theme.LocalTypography
@@ -119,7 +119,7 @@ private fun AuthorsListScreen(
                     .fillMaxSize()
             ) {
                 if (state.isLoading) {
-                    CircularProgressIndicator(
+                    ProgressIndicator(
                         modifier = Modifier
                             .align(Alignment.Center)
                     )
@@ -268,7 +268,7 @@ fun AuthorItem(
                         .size(70.dp)
                         .clip(RoundedCornerShape(8.dp)),
                     loading = {
-                        CircularProgressIndicator(
+                        ProgressIndicator(
                             modifier = Modifier
                                 .size(50.dp)
                         )

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -24,6 +23,7 @@ import com.firdavs.persianliterature.ui.kit.BaseScreen
 import com.firdavs.persianliterature.ui.kit.H2Text
 import com.firdavs.persianliterature.ui.kit.H3Text
 import com.firdavs.persianliterature.ui.kit.H4Text
+import com.firdavs.persianliterature.ui.kit.components.ProgressIndicator
 import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 import com.rajat.pdfviewer.compose.PdfRendererViewCompose
 import com.rajat.pdfviewer.util.PdfSource
@@ -100,7 +100,7 @@ fun WorkDetailsScreen(
                 verticalArrangement = Arrangement.Center
             ) {
                 if (state.isLoading) {
-                    CircularProgressIndicator()
+                    ProgressIndicator()
                     H4Text(text = stringResource(R.string.work_loading))
                 } else if (state.work != null) {
                     state.workFile?.let { workFile ->

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/ProgressIndicator.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/ProgressIndicator.kt
@@ -1,0 +1,16 @@
+package com.firdavs.persianliterature.ui.kit.components
+
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.firdavs.persianliterature.ui.kit.theme.LocalColors
+
+@Composable
+fun ProgressIndicator(
+    modifier: Modifier = Modifier
+) {
+    CircularProgressIndicator(
+        modifier = modifier,
+        color = LocalColors.current.primary
+    )
+}


### PR DESCRIPTION
## Summary
Changed progress bar color from purple to primary (Gold) and created a reusable component in ui_kit module.

## Changes
- Created `ProgressIndicator` composable in ui_kit/components
- Updated all 5 progress bar usages across 3 screens
- Progress bars now use primary color (Gold) instead of default purple

Fixes #16

Generated with [Claude Code](https://claude.ai/code)