### PR TITLE
Implement lazy loading and manual refresh for authors list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ android {
 }
 
 dependencies {
+    implementation module.author_api
     implementation module.core
     implementation module.ui_kit
     implementation module.author_ui

--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainViewModel.kt
@@ -1,5 +1,43 @@
 package com.firdavs.persianliterature.app.ui
 
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.firdavs.persianliterature.author_api.repository.AuthorRepository
+import com.firdavs.persianliterature.author_api.repository.WorksRepository
 import com.firdavs.persianliterature.core.presentation.BaseViewModel
+import kotlinx.coroutines.launch
 
-class MainViewModel : BaseViewModel<MainActivityUiState>(MainActivityUiState())
+class MainViewModel(
+    private val authorRepository: AuthorRepository,
+    private val worksRepository: WorksRepository
+) : BaseViewModel<MainActivityUiState>(MainActivityUiState()) {
+
+    init {
+        fetchAuthors()
+        fetchWorks()
+    }
+
+    private fun fetchAuthors() {
+        viewModelScope.launch {
+            runCatching {
+                authorRepository.fetchAuthors()
+            }.onFailure {
+                Log.e(TAG, "fetchAuthors error ", it)
+            }
+        }
+    }
+
+    private fun fetchWorks() {
+        viewModelScope.launch {
+            runCatching {
+                worksRepository.fetchWorks()
+            }.onFailure {
+                Log.e(TAG, "fetchWorks error ", it)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "MainViewModel"
+    }
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/favourites/FavouritesScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
@@ -1,5 +1,6 @@
 package com.firdavs.persianliterature.author.ui.list
 
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -76,7 +78,8 @@ fun AuthorsListEntryPoint(
             filterAuthorsList = viewModel::filterAuthorsList,
             onChapterClick = onChapterClick,
             onToggleFavourite = viewModel::onToggleFavourite,
-            onRefreshClick = viewModel::onRefreshClick
+            onRefreshClick = viewModel::onRefreshClick,
+            resetShowToastFlag = viewModel::resetShowToastFlag
         )
     }
 }
@@ -93,8 +96,20 @@ private fun AuthorsListScreen(
     filterAuthorsList: () -> Unit,
     onChapterClick: (Chapter) -> Unit,
     onToggleFavourite: (String, Boolean) -> Unit,
-    onRefreshClick: () -> Unit
+    onRefreshClick: () -> Unit,
+    resetShowToastFlag: () -> Unit
 ) {
+    val context = LocalContext.current
+    LaunchedEffect(state.showToast) {
+        if (state.showToast) {
+            Toast.makeText(
+                context,
+                R.string.authors_fetched,
+                Toast.LENGTH_SHORT
+            ).show()
+            resetShowToastFlag()
+        }
+    }
     BaseScreen(
         drawerContent = {
             DrawerSheet(
@@ -349,7 +364,8 @@ private fun AuthorsListScreenPreview(
             filterAuthorsList = {},
             onChapterClick = {},
             onToggleFavourite = { _, _ -> },
-            onRefreshClick = {}
+            onRefreshClick = {},
+            resetShowToastFlag = {}
         )
     }
 }

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.CircularProgressIndicator
@@ -74,7 +75,8 @@ fun AuthorsListEntryPoint(
             onAuthorClick = onAuthorClick,
             filterAuthorsList = viewModel::filterAuthorsList,
             onChapterClick = onChapterClick,
-            onToggleFavourite = viewModel::onToggleFavourite
+            onToggleFavourite = viewModel::onToggleFavourite,
+            onRefreshClick = viewModel::onRefreshClick
         )
     }
 }
@@ -90,7 +92,8 @@ private fun AuthorsListScreen(
     onAuthorClick: (String) -> Unit,
     filterAuthorsList: () -> Unit,
     onChapterClick: (Chapter) -> Unit,
-    onToggleFavourite: (String, Boolean) -> Unit
+    onToggleFavourite: (String, Boolean) -> Unit,
+    onRefreshClick: () -> Unit
 ) {
     BaseScreen(
         drawerContent = {
@@ -110,7 +113,9 @@ private fun AuthorsListScreen(
                 onClearSearchQueryClick = onClearSearchQueryClick,
                 onSearchClick = onSearchClick,
                 onExitSearchClick = onExitSearchClick,
-                filterAuthorsList = filterAuthorsList
+                filterAuthorsList = filterAuthorsList,
+                isRefreshing = state.isRefreshing,
+                onRefreshClick = onRefreshClick
             )
         },
         mainContent = {
@@ -159,7 +164,9 @@ private fun TopBar(
     onClearSearchQueryClick: () -> Unit,
     onSearchClick: () -> Unit,
     onExitSearchClick: () -> Unit,
-    filterAuthorsList: () -> Unit
+    filterAuthorsList: () -> Unit,
+    isRefreshing: Boolean,
+    onRefreshClick: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -225,6 +232,15 @@ private fun TopBar(
             Spacer(Modifier.weight(1f))
             H3Text(text = stringResource(R.string.authors_list))
             Spacer(Modifier.weight(1f))
+            IconButton(
+                onClick = onRefreshClick,
+                enabled = !isRefreshing
+            ) {
+                Icon(
+                    Icons.Default.Refresh,
+                    contentDescription = "Refresh"
+                )
+            }
             IconButton(onClick = onSearchClick) {
                 Icon(
                     Icons.Default.Search,
@@ -332,7 +348,8 @@ private fun AuthorsListScreenPreview(
             onAuthorClick = {},
             filterAuthorsList = {},
             onChapterClick = {},
-            onToggleFavourite = { _, _ -> }
+            onToggleFavourite = { _, _ -> },
+            onRefreshClick = {}
         )
     }
 }

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
@@ -10,5 +10,6 @@ data class AuthorsListUiState(
     val searchQuery: String = "",
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
+    val showToast: Boolean = false,
     val chapters: List<Chapter> = Chapter.all
 ) : UiState()

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListUiState.kt
@@ -9,5 +9,6 @@ data class AuthorsListUiState(
     val isSearchActive: Boolean = false,
     val searchQuery: String = "",
     val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
     val chapters: List<Chapter> = Chapter.all
 ) : UiState()

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
@@ -62,6 +62,10 @@ class AuthorsListViewModel(
         }
     }
 
+    fun resetShowToastFlag() {
+        post { it.copy(showToast = false) }
+    }
+
     fun onRefreshClick() {
         post { it.copy(isRefreshing = true) }
         viewModelScope.launch {
@@ -73,6 +77,7 @@ class AuthorsListViewModel(
                 post { it.copy(isRefreshing = false) }
             }.onSuccess {
                 post { it.copy(isRefreshing = false) }
+                post { it.copy(showToast = true) }
             }
         }
     }

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
@@ -22,44 +22,12 @@ class AuthorsListViewModel(
     }
 
     private var allAuthors: List<AuthorUiModel> = emptyList()
-    private var hasInitiallyFetched = false
 
-    override fun onViewResumed() {
-        if (!hasInitiallyFetched) {
-            hasInitiallyFetched = true
-            fetchAuthors()
-            fetchWorks()
-        }
-    }
     private fun observeAuthors() {
         viewModelScope.launch {
             authorRepository.getAuthors().collect { authors ->
                 allAuthors = authorUiMapper.map(authors)
-                post { it.copy(authors = allAuthors) }
-            }
-        }
-    }
-
-    private fun fetchAuthors() {
-        post { it.copy(isLoading = true) }
-        viewModelScope.launch {
-            runCatching {
-                authorRepository.fetchAuthors()
-            }.onFailure {
-                Log.e(TAG, "getAuthors error ", it)
-                post { it.copy(isLoading = false) }
-            }.onSuccess {
-                post { it.copy(isLoading = false) }
-            }
-        }
-    }
-
-    private fun fetchWorks() {
-        viewModelScope.launch {
-            runCatching {
-                worksRepository.fetchWorks()
-            }.onFailure {
-                Log.e(TAG, "fetchWorks error ", it)
+                post { it.copy(authors = allAuthors, isLoading = false) }
             }
         }
     }

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
@@ -19,11 +19,18 @@ class AuthorsListViewModel(
     BaseViewModel<AuthorsListUiState>(AuthorsListUiState()) {
     init {
         observeAuthors()
-        fetchAuthors()
-        fetchWorks()
     }
 
     private var allAuthors: List<AuthorUiModel> = emptyList()
+    private var hasInitiallyFetched = false
+
+    override fun onViewResumed() {
+        if (!hasInitiallyFetched) {
+            hasInitiallyFetched = true
+            fetchAuthors()
+            fetchWorks()
+        }
+    }
     private fun observeAuthors() {
         viewModelScope.launch {
             authorRepository.getAuthors().collect { authors ->
@@ -84,6 +91,21 @@ class AuthorsListViewModel(
     fun onToggleFavourite(authorId: String, isFavourite: Boolean) {
         viewModelScope.launch {
             favouritesRepository.toggleAuthorFavourite(authorId, isFavourite)
+        }
+    }
+
+    fun onRefreshClick() {
+        post { it.copy(isRefreshing = true) }
+        viewModelScope.launch {
+            runCatching {
+                authorRepository.fetchAuthors()
+                worksRepository.fetchWorks()
+            }.onFailure {
+                Log.e(TAG, "onRefreshClick error ", it)
+                post { it.copy(isRefreshing = false) }
+            }.onSuccess {
+                post { it.copy(isRefreshing = false) }
+            }
         }
     }
 

--- a/author_ui/src/main/res/values-ru/strings.xml
+++ b/author_ui/src/main/res/values-ru/strings.xml
@@ -12,4 +12,5 @@
     <string name="published_at">опубликовано %s</string>
     <string name="no_favourite_authors">Нет избранных авторов</string>
     <string name="no_favourite_works">Нет избранных произведений</string>
+    <string name="authors_fetched">Список авторов обновлен</string>
 </resources>

--- a/author_ui/src/main/res/values-tg/strings.xml
+++ b/author_ui/src/main/res/values-tg/strings.xml
@@ -12,4 +12,5 @@
     <string name="published_at">нашр шуд дар %s</string>
     <string name="no_favourite_authors">Муаллифони интихобшуда нест</string>
     <string name="no_favourite_works">Асарҳои интихобшуда нест</string>
+    <string name="authors_fetched">Рӯйхати муаллифон аз нав гирифта шуд</string>
 </resources>

--- a/author_ui/src/main/res/values/strings.xml
+++ b/author_ui/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="published_at">published at %s</string>
     <string name="no_favourite_authors">No favourite authors yet</string>
     <string name="no_favourite_works">No favourite works yet</string>
+    <string name="authors_fetched">Authors fetched successfully</string>
 </resources>


### PR DESCRIPTION
Fixes #15

## Changes
- Move data fetching from init to onViewResumed() with flag to ensure it only runs once on app launch
- Add refresh icon to authors list TopBar next to search icon
- Implement onRefreshClick() action in ViewModel with isRefreshing state
- Add isRefreshing field to AuthorsListUiState
- Refresh button fetches both authors and works data from Firebase

Generated with [Claude Code](https://claude.ai/code)