### PR TITLE
fix: prevent AudioControlsSection blinking during skip operations

### DIFF
--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -249,8 +249,8 @@ fun AudioControlsSection(
                 }
             }
             state.work?.audioDownloadStatus == AudioDownloadStatus.DOWNLOADED -> {
-                if (state.playbackState.isPreparing) {
-                    // Show loading indicator while preparing
+                if (state.playbackState.isPreparing && !state.hasCompletedInitialPreparation) {
+                    // Show loading indicator only during initial preparation
                     Column(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalAlignment = CenterHorizontally

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsUiState.kt
@@ -15,5 +15,6 @@ data class WorkDetailsUiState(
     val audioDownloadProgress: Float = 0f,
     val audioDownloadError: String? = null,
     val playbackState: PlaybackState = PlaybackState(),
-    val currentlyPreparedAudioPath: String? = null
+    val currentlyPreparedAudioPath: String? = null,
+    val hasCompletedInitialPreparation: Boolean = false
 ) : UiState()

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsViewModel.kt
@@ -115,6 +115,17 @@ class WorkDetailsViewModel(
                     val currentAudioPath = it.audioFile?.absolutePath
                     val isThisWorkPlaying = playbackState.audioUrl == currentAudioPath
 
+                    // Track if we've completed initial preparation
+                    val hasCompletedPreparation = if (isThisWorkPlaying &&
+                        !playbackState.isPreparing &&
+                        playbackState.duration > 0) {
+                        true
+                    } else if (!isThisWorkPlaying) {
+                        false // Reset when switching to different audio
+                    } else {
+                        it.hasCompletedInitialPreparation
+                    }
+
                     it.copy(
                         playbackState = if (isThisWorkPlaying) {
                             playbackState
@@ -126,7 +137,8 @@ class WorkDetailsViewModel(
                             playbackState.error
                         } else {
                             it.audioDownloadError
-                        }
+                        },
+                        hasCompletedInitialPreparation = hasCompletedPreparation
                     )
                 }
             }


### PR DESCRIPTION
Track initial audio preparation completion to avoid showing loading
indicator during seek operations. The loading indicator now only
displays during the first preparation phase, preventing the UI from
flickering when users skip forward or backward by 10 seconds.

Fixes #28

Generated with [Claude Code](https://claude.ai/code)