### PR TITLE
fix: remove gray bar under status bar when hiding UI

### DIFF
--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -87,6 +87,7 @@ fun WorkDetailsScreen(
     var isBarsVisible by remember { mutableStateOf(true) }
 
     BaseScreen(
+        applyTopPadding = isBarsVisible,
         topBar = { drawerState, scope ->
             AnimatedVisibility(isBarsVisible) {
                 Box(

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/BaseScreen.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/BaseScreen.kt
@@ -33,7 +33,8 @@ fun BaseScreen(
     drawerContent: (@Composable () -> Unit)? = null,
     topBar: (@Composable (DrawerState, CoroutineScope) -> Unit)? = null,
     mainContent: @Composable () -> Unit,
-    footerContent: (@Composable BoxScope.() -> Unit)? = null
+    footerContent: (@Composable BoxScope.() -> Unit)? = null,
+    applyTopPadding: Boolean = true
 ) {
     val backgroundColor = LocalColors.current.background
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -54,7 +55,7 @@ fun BaseScreen(
                         modifier = Modifier
                             .weight(1f)
                             .fillMaxWidth()
-                            .padding(top = innerPadding.calculateTopPadding())
+                            .padding(top = if (applyTopPadding) innerPadding.calculateTopPadding() else 0.dp)
                             .thenIfNotNull(footerContent) { drawShadow() }
                     ) {
                         mainContent()


### PR DESCRIPTION
Fixes the gray bar that appeared under the status bar when hiding top/bottom bars in WorkDetailsScreen.

## Changes
- Added `applyTopPadding` parameter to BaseScreen to conditionally apply top padding
- Pass `isBarsVisible` state from WorkDetailsScreen to control top padding
- PDF viewer now extends fully to screen edges when bars are hidden

Fixes #26

Generated with [Claude Code](https://claude.ai/code)