### PR TITLE
feat: add Audio Books chapter

### DIFF
--- a/app/src/main/java/com/firdavs/persianliterature/app/navigation/Navigator.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/navigation/Navigator.kt
@@ -21,6 +21,7 @@ import com.firdavs.persianliterature.about_app.ui.AboutAppEntryPoint
 import com.firdavs.persianliterature.app.R
 import com.firdavs.persianliterature.app.ui.MainActivityUiState
 import com.firdavs.persianliterature.settings.SettingsEntryPoint
+import com.firdavs.persianliterature.author.ui.audio_books.AudioBooksEntryPoint
 import com.firdavs.persianliterature.author.ui.details.AuthorDetailsEntryPoint
 import com.firdavs.persianliterature.author.ui.favourites.FavouritesEntryPoint
 import com.firdavs.persianliterature.author.ui.list.AuthorsListEntryPoint
@@ -71,6 +72,7 @@ fun Navigator(
                     onAuthorClick = { backStack.next(Route.AuthorDetails(it)) },
                     onChapterClick = { chapter ->
                         when (chapter) {
+                            Chapter.AudioBooks -> backStack.startNewRoot(Route.AudioBooks)
                             Chapter.AboutApp -> backStack.startNewRoot(Route.AboutApp)
                             Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
                             Chapter.Settings -> backStack.startNewRoot(Route.Settings)
@@ -92,11 +94,26 @@ fun Navigator(
                     onBackClick = onBack
                 )
             }
+            entry<Route.AudioBooks> {
+                AudioBooksEntryPoint(
+                    onChapterClick = { chapter ->
+                        when (chapter) {
+                            Chapter.Authors -> backStack.startNewRoot(Route.AuthorsList)
+                            Chapter.AboutApp -> backStack.startNewRoot(Route.AboutApp)
+                            Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
+                            Chapter.Settings -> backStack.startNewRoot(Route.Settings)
+                            else -> {}
+                        }
+                    },
+                    onWorkClick = { backStack.next(Route.WorkDetails(it)) }
+                )
+            }
             entry<Route.AboutApp> {
                 AboutAppEntryPoint(
                     onChapterClick = { chapter ->
                         when (chapter) {
                             Chapter.Authors -> backStack.startNewRoot(Route.AuthorsList)
+                            Chapter.AudioBooks -> backStack.startNewRoot(Route.AudioBooks)
                             Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
                             Chapter.Settings -> backStack.startNewRoot(Route.Settings)
                             else -> {}
@@ -109,6 +126,7 @@ fun Navigator(
                     onChapterClick = { chapter ->
                         when (chapter) {
                             Chapter.Authors -> backStack.startNewRoot(Route.AuthorsList)
+                            Chapter.AudioBooks -> backStack.startNewRoot(Route.AudioBooks)
                             Chapter.AboutApp -> backStack.startNewRoot(Route.AboutApp)
                             Chapter.Settings -> backStack.startNewRoot(Route.Settings)
                             else -> {}
@@ -123,6 +141,7 @@ fun Navigator(
                     onChapterClick = { chapter ->
                         when (chapter) {
                             Chapter.Authors -> backStack.startNewRoot(Route.AuthorsList)
+                            Chapter.AudioBooks -> backStack.startNewRoot(Route.AudioBooks)
                             Chapter.AboutApp -> backStack.startNewRoot(Route.AboutApp)
                             Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
                             else -> {}

--- a/app/src/main/java/com/firdavs/persianliterature/app/navigation/Route.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/navigation/Route.kt
@@ -14,6 +14,9 @@ sealed interface Route : NavKey {
     data class WorkDetails(val id: String) : Route
 
     @Serializable
+    object AudioBooks : Route
+
+    @Serializable
     object AboutApp : Route
 
     @Serializable

--- a/author/src/main/java/com/firdavs/persianliterature/author/db/dao/WorksDao.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/dao/WorksDao.kt
@@ -58,10 +58,13 @@ interface WorksDao {
 
     @Query(
         """
-        SELECT * 
-        FROM ${AuthorsDb.WORKS} 
+        SELECT *
+        FROM ${AuthorsDb.WORKS}
         WHERE audioUrl IS NOT NULL AND audioDownloadStatus = 'DOWNLOADED'
         """
     )
     fun getWorksWithDownloadedAudio(): Flow<List<WorkEntity>>
+
+    @Query("SELECT * FROM ${AuthorsDb.WORKS} WHERE audioUrl IS NOT NULL")
+    fun getWorksWithAudio(): Flow<List<WorkEntity>>
 }

--- a/author/src/main/java/com/firdavs/persianliterature/author/repository/WorksRepositoryImpl.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/repository/WorksRepositoryImpl.kt
@@ -72,4 +72,10 @@ class WorksRepositoryImpl(
             works.toDomain()
         }
     }
+
+    override fun getWorksWithAudio(): Flow<List<Work>> {
+        return worksDao.getWorksWithAudio().map { works ->
+            works.toDomain()
+        }
+    }
 }

--- a/author_api/src/main/java/com/firdavs/persianliterature/author_api/repository/WorksRepository.kt
+++ b/author_api/src/main/java/com/firdavs/persianliterature/author_api/repository/WorksRepository.kt
@@ -16,4 +16,5 @@ interface WorksRepository {
         localPath: String? = null
     )
     fun getWorksWithDownloadedAudio(): Flow<List<Work>>
+    fun getWorksWithAudio(): Flow<List<Work>>
 }

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksScreen.kt
@@ -1,5 +1,6 @@
 package com.firdavs.persianliterature.author.ui.audio_books
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -64,6 +65,7 @@ private fun AudioBooksScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .background(LocalColors.current.primary)
                     .padding(horizontal = 8.dp)
             ) {
                 IconButton(

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksScreen.kt
@@ -1,0 +1,143 @@
+package com.firdavs.persianliterature.author.ui.audio_books
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.firdavs.persianliterature.author.ui.R
+import com.firdavs.persianliterature.author_api.model.Work
+import com.firdavs.persianliterature.core.model.Chapter
+import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
+import com.firdavs.persianliterature.ui.kit.BaseScreen
+import com.firdavs.persianliterature.ui.kit.H3Text
+import com.firdavs.persianliterature.ui.kit.H4Text
+import com.firdavs.persianliterature.ui.kit.H5Text
+import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
+import com.firdavs.persianliterature.ui.kit.theme.LocalColors
+import kotlinx.coroutines.launch
+
+@Composable
+fun AudioBooksEntryPoint(
+    onChapterClick: (Chapter) -> Unit,
+    onWorkClick: (String) -> Unit
+) {
+    BaseEntryPoint(AudioBooksViewModel::class) { state, _ ->
+        AudioBooksScreen(
+            state = state,
+            onChapterClick = onChapterClick,
+            onWorkClick = onWorkClick
+        )
+    }
+}
+
+@Composable
+private fun AudioBooksScreen(
+    state: AudioBooksUiState,
+    onChapterClick: (Chapter) -> Unit,
+    onWorkClick: (String) -> Unit
+) {
+    BaseScreen(
+        drawerContent = {
+            DrawerSheet(
+                chapters = state.chapters,
+                currentChapter = Chapter.AudioBooks,
+                onChapterClick = onChapterClick
+            )
+        },
+        topBar = { drawerState, scope ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
+                IconButton(
+                    onClick = { scope.launch { drawerState.open() } }
+                ) {
+                    Icon(Icons.Default.Menu, "Open drawer")
+                }
+                H3Text(
+                    modifier = Modifier.align(Alignment.Center),
+                    text = stringResource(com.firdavs.persianliterature.core.R.string.audio_books),
+                    textAlign = TextAlign.Center
+                )
+            }
+        },
+        mainContent = {
+            AudioBooksContent(
+                works = state.works,
+                onWorkClick = onWorkClick
+            )
+        }
+    )
+}
+
+@Composable
+private fun AudioBooksContent(
+    works: List<Work>,
+    onWorkClick: (String) -> Unit
+) {
+    if (works.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            H4Text(
+                text = stringResource(R.string.no_audio_books_found),
+                textAlign = TextAlign.Center
+            )
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(works) { work ->
+                AudioBookItem(
+                    work = work,
+                    onWorkClick = onWorkClick
+                )
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    thickness = 1.dp,
+                    color = LocalColors.current.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AudioBookItem(
+    work: Work,
+    onWorkClick: (String) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onWorkClick(work.id) }
+            .padding(horizontal = 16.dp)
+    ) {
+        H4Text(text = work.title)
+        work.publishYear?.let { year ->
+            H5Text(text = stringResource(R.string.published_at, year))
+        }
+    }
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksUiState.kt
@@ -1,0 +1,10 @@
+package com.firdavs.persianliterature.author.ui.audio_books
+
+import com.firdavs.persianliterature.author_api.model.Work
+import com.firdavs.persianliterature.core.model.Chapter
+import com.firdavs.persianliterature.core.presentation.UiState
+
+data class AudioBooksUiState(
+    val works: List<Work> = emptyList(),
+    val chapters: List<Chapter> = Chapter.all
+) : UiState()

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/audio_books/AudioBooksViewModel.kt
@@ -1,0 +1,23 @@
+package com.firdavs.persianliterature.author.ui.audio_books
+
+import androidx.lifecycle.viewModelScope
+import com.firdavs.persianliterature.author_api.repository.WorksRepository
+import com.firdavs.persianliterature.core.presentation.BaseViewModel
+import kotlinx.coroutines.launch
+
+class AudioBooksViewModel(
+    private val worksRepository: WorksRepository
+) : BaseViewModel<AudioBooksUiState>(AudioBooksUiState()) {
+
+    init {
+        observeWorksWithAudio()
+    }
+
+    private fun observeWorksWithAudio() {
+        viewModelScope.launch {
+            worksRepository.getWorksWithAudio().collect { works ->
+                post { it.copy(works = works) }
+            }
+        }
+    }
+}

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/di/Module.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/di/Module.kt
@@ -1,5 +1,6 @@
 package com.firdavs.persianliterature.author.ui.di
 
+import com.firdavs.persianliterature.author.ui.audio_books.AudioBooksViewModel
 import com.firdavs.persianliterature.author.ui.details.AuthorDetailsViewModel
 import com.firdavs.persianliterature.author.ui.favourites.FavouritesViewModel
 import com.firdavs.persianliterature.author.ui.list.AuthorsListViewModel
@@ -16,6 +17,7 @@ import org.koin.dsl.module
 val authorUiModule = module {
     viewModelOf(::AuthorsListViewModel)
     viewModelOf(::FavouritesViewModel)
+    viewModelOf(::AudioBooksViewModel)
     viewModel {
             (args: Array<Any?>) -> AuthorDetailsViewModel(
         args.first() as String,

--- a/author_ui/src/main/res/values-ru/strings.xml
+++ b/author_ui/src/main/res/values-ru/strings.xml
@@ -22,4 +22,5 @@
     <string name="now_playing">Воспроизведение</string>
     <string name="download_failed">Ошибка Загрузки</string>
     <string name="retry_download">Повторить</string>
+    <string name="no_audio_books_found">Аудиокниги пока недоступны</string>
 </resources>

--- a/author_ui/src/main/res/values-tg/strings.xml
+++ b/author_ui/src/main/res/values-tg/strings.xml
@@ -22,4 +22,5 @@
     <string name="now_playing">Дар ҳоли пахш</string>
     <string name="download_failed">Зеркашӣ ноком шуд</string>
     <string name="retry_download">Аз нав кӯшиш кунед</string>
+    <string name="no_audio_books_found">Китобҳои аудиоӣ ҳанӯз дастрас нестанд</string>
 </resources>

--- a/author_ui/src/main/res/values/strings.xml
+++ b/author_ui/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="now_playing">Now Playing</string>
     <string name="download_failed">Download Failed</string>
     <string name="retry_download">Retry</string>
+    <string name="no_audio_books_found">No audio books available yet</string>
 </resources>

--- a/core/src/main/java/com/firdavs/persianliterature/core/model/Chapter.kt
+++ b/core/src/main/java/com/firdavs/persianliterature/core/model/Chapter.kt
@@ -4,11 +4,12 @@ import com.firdavs.persianliterature.core.R
 
 enum class Chapter(val titleRes: Int) {
     Authors(R.string.authors),
+    AudioBooks(R.string.audio_books),
     AboutApp(R.string.about_app),
     Favourites(R.string.favourites),
     Settings(R.string.settings);
 
     companion object {
-        val all = listOf(Authors, AboutApp, Favourites, Settings)
+        val all = listOf(Authors, AudioBooks, AboutApp, Favourites, Settings)
     }
 }

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -4,4 +4,5 @@
     <string name="favourites">Избранное</string>
     <string name="settings">Настройки</string>
     <string name="authors">Авторы</string>
+    <string name="audio_books">Аудиокниги</string>
 </resources>

--- a/core/src/main/res/values-tg/strings.xml
+++ b/core/src/main/res/values-tg/strings.xml
@@ -4,4 +4,5 @@
     <string name="favourites">Интихобшуда</string>
     <string name="settings">Танзимот</string>
     <string name="authors">Муаллифон</string>
+    <string name="audio_books">Китобҳои аудиоӣ</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="favourites">Favourites</string>
     <string name="settings">Settings</string>
     <string name="authors">Authors</string>
+    <string name="audio_books">Audio books</string>
 </resources>


### PR DESCRIPTION
Fixes #27

Adds a new "Audio Books" chapter to the navigation drawer that displays all works with audio versions (audioUrl != null).

**Changes:**
- Added AudioBooks chapter to Chapter enum
- Created AudioBooksViewModel, AudioBooksScreen, and AudioBooksUiState
- Added DAO and repository methods to query works with audio
- Integrated into navigation system with proper routing
- Added localized strings for English, Russian, and Tajik

Clicking on a work in the Audio Books screen opens the WorkDetailsScreen.

Generated with [Claude Code](https://claude.ai/code)