### PR TITLE
feat: redesign Settings screen with separate Language screen

### DIFF
--- a/app/src/main/java/com/firdavs/persianliterature/app/di/Module.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/di/Module.kt
@@ -7,6 +7,7 @@ import com.firdavs.persianliterature.author.di.authorModule
 import com.firdavs.persianliterature.author.ui.di.authorUiModule
 import com.firdavs.persianliterature.settings.DailyNotificationWorker
 import com.firdavs.persianliterature.settings.LanguageManagerImpl
+import com.firdavs.persianliterature.settings.LanguageViewModel
 import com.firdavs.persianliterature.settings.NotificationManagerImpl
 import com.firdavs.persianliterature.settings.SettingsViewModel
 import com.firdavs.persianliterature.settings.api.LanguageManager
@@ -21,6 +22,7 @@ import org.koin.dsl.module
 val appModule = module {
     viewModelOf(::MainViewModel)
     viewModelOf(::SettingsViewModel)
+    viewModelOf(::LanguageViewModel)
     singleOf(::LanguageManagerImpl) bind LanguageManager::class
     singleOf(::NotificationManagerImpl) bind NotificationManager::class
 

--- a/app/src/main/java/com/firdavs/persianliterature/app/navigation/Navigator.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/navigation/Navigator.kt
@@ -20,6 +20,7 @@ import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import com.firdavs.persianliterature.about_app.ui.AboutAppEntryPoint
 import com.firdavs.persianliterature.app.R
 import com.firdavs.persianliterature.app.ui.MainActivityUiState
+import com.firdavs.persianliterature.settings.LanguageEntryPoint
 import com.firdavs.persianliterature.settings.SettingsEntryPoint
 import com.firdavs.persianliterature.author.ui.audio_books.AudioBooksEntryPoint
 import com.firdavs.persianliterature.author.ui.details.AuthorDetailsEntryPoint
@@ -147,7 +148,13 @@ fun Navigator(
                             Chapter.Favourites -> backStack.startNewRoot(Route.Favourites)
                             else -> {}
                         }
-                    }
+                    },
+                    onChangeLanguageClick = { backStack.next(Route.Language) }
+                )
+            }
+            entry<Route.Language> {
+                LanguageEntryPoint(
+                    onBackClick = onBack
                 )
             }
         }

--- a/app/src/main/java/com/firdavs/persianliterature/app/navigation/Route.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/navigation/Route.kt
@@ -24,4 +24,7 @@ sealed interface Route : NavKey {
 
     @Serializable
     object Settings : Route
+
+    @Serializable
+    object Language : Route
 }

--- a/settings/src/main/java/com/firdavs/persianliterature/settings/LanguageScreen.kt
+++ b/settings/src/main/java/com/firdavs/persianliterature/settings/LanguageScreen.kt
@@ -1,0 +1,138 @@
+package com.firdavs.persianliterature.settings
+
+import android.app.LocaleManager
+import android.content.Context
+import android.os.Build
+import android.os.LocaleList
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import com.firdavs.persianliterature.settings.api.Language
+import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
+import com.firdavs.persianliterature.ui.kit.BaseScreen
+import com.firdavs.persianliterature.ui.kit.H3Text
+import com.firdavs.persianliterature.ui.kit.components.buttons.PrimaryButton
+import com.firdavs.persianliterature.ui.kit.theme.LocalColors
+import com.firdavs.persianliterature.core.R as UiR
+
+@Composable
+fun LanguageEntryPoint(
+    onBackClick: () -> Unit
+) {
+    val context = LocalContext.current
+
+    BaseEntryPoint(LanguageViewModel::class) { state, viewModel ->
+        LanguageScreen(
+            state = state,
+            onBackClick = onBackClick,
+            onLanguageSelected = viewModel::onLanguageSelected,
+            onApplyClick = { language ->
+                viewModel.onApplyClick(language)
+                changeLocale(language.code, context)
+            }
+        )
+    }
+}
+
+private fun changeLocale(languageCode: String, context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.getSystemService(LocaleManager::class.java)
+            .applicationLocales = LocaleList.forLanguageTags(languageCode)
+    } else {
+        AppCompatDelegate.setApplicationLocales(
+            LocaleListCompat.forLanguageTags(languageCode)
+        )
+    }
+}
+
+@Composable
+private fun LanguageScreen(
+    state: LanguageUiState,
+    onBackClick: () -> Unit,
+    onLanguageSelected: (Language) -> Unit,
+    onApplyClick: (Language) -> Unit
+) {
+    val colors = LocalColors.current
+    BaseScreen(
+        topBar = { _, _ ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(LocalColors.current.primary)
+                    .padding(horizontal = 8.dp)
+            ) {
+                IconButton(
+                    onClick = onBackClick
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                }
+                H3Text(
+                    modifier = Modifier
+                        .align(Alignment.Center),
+                    text = stringResource(R.string.select_language),
+                    textAlign = TextAlign.Center
+                )
+            }
+        },
+        mainContent = {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                H3Text(
+                    text = stringResource(R.string.select_language)
+                )
+
+                Language.entries.forEach { language ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(
+                            selected = state.selectedLanguage == language,
+                            onClick = { onLanguageSelected(language) },
+                            colors = RadioButtonDefaults.colors().copy(
+                                selectedColor = colors.primary
+                            )
+                        )
+                        H3Text(
+                            modifier = Modifier.padding(start = 8.dp),
+                            text = language.displayName
+                        )
+                    }
+                }
+                PrimaryButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    text = stringResource(R.string.apply),
+                    onClick = { onApplyClick(state.selectedLanguage) }
+                )
+            }
+        }
+    )
+}

--- a/settings/src/main/java/com/firdavs/persianliterature/settings/LanguageUiState.kt
+++ b/settings/src/main/java/com/firdavs/persianliterature/settings/LanguageUiState.kt
@@ -2,8 +2,9 @@ package com.firdavs.persianliterature.settings
 
 import com.firdavs.persianliterature.core.model.Chapter
 import com.firdavs.persianliterature.core.presentation.UiState
+import com.firdavs.persianliterature.settings.api.Language
 
-data class SettingsUiState(
+data class LanguageUiState(
     val chapters: List<Chapter> = Chapter.all,
-    val notificationsEnabled: Boolean = false
+    val selectedLanguage: Language = Language.ENGLISH
 ) : UiState()

--- a/settings/src/main/java/com/firdavs/persianliterature/settings/LanguageViewModel.kt
+++ b/settings/src/main/java/com/firdavs/persianliterature/settings/LanguageViewModel.kt
@@ -1,0 +1,29 @@
+package com.firdavs.persianliterature.settings
+
+import android.app.Application
+import com.firdavs.persianliterature.core.presentation.BaseViewModel
+import com.firdavs.persianliterature.settings.api.Language
+import com.firdavs.persianliterature.settings.api.LanguageManager
+
+class LanguageViewModel(
+    private val application: Application,
+    private val languageManager: LanguageManager
+) : BaseViewModel<LanguageUiState>(LanguageUiState()) {
+
+    init {
+        val savedLanguage = languageManager.getSavedLanguage(application)
+        post {
+            it.copy(selectedLanguage = savedLanguage)
+        }
+    }
+
+    fun onLanguageSelected(language: Language) {
+        post {
+            it.copy(selectedLanguage = language)
+        }
+    }
+
+    fun onApplyClick(language: Language) {
+        languageManager.setLanguage(application, language)
+    }
+}

--- a/settings/src/main/java/com/firdavs/persianliterature/settings/SettingsScreen.kt
+++ b/settings/src/main/java/com/firdavs/persianliterature/settings/SettingsScreen.kt
@@ -1,13 +1,9 @@
 package com.firdavs.persianliterature.settings
 
 import android.Manifest
-import android.app.LocaleManager
-import android.content.Context
 import android.os.Build
-import android.os.LocaleList
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,21 +17,16 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.core.os.LocaleListCompat
 import com.firdavs.persianliterature.core.model.Chapter
-import com.firdavs.persianliterature.settings.api.Language
 import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
 import com.firdavs.persianliterature.ui.kit.BaseScreen
 import com.firdavs.persianliterature.ui.kit.H3Text
@@ -47,10 +38,9 @@ import com.firdavs.persianliterature.core.R as UiR
 
 @Composable
 fun SettingsEntryPoint(
-    onChapterClick: (Chapter) -> Unit
+    onChapterClick: (Chapter) -> Unit,
+    onChangeLanguageClick: () -> Unit
 ) {
-    val context = LocalContext.current
-
     BaseEntryPoint(SettingsViewModel::class) { state, viewModel ->
         val permissionLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.RequestPermission()
@@ -63,11 +53,7 @@ fun SettingsEntryPoint(
         SettingsScreen(
             state = state,
             onChapterClick = onChapterClick,
-            onLanguageSelected = viewModel::onLanguageSelected,
-            onApplyClick = { language ->
-                viewModel.onApplyClick(language)
-                changeLocale(language.code, context)
-            },
+            onChangeLanguageClick = onChangeLanguageClick,
             onNotificationToggle = { enabled ->
                 if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
@@ -79,23 +65,11 @@ fun SettingsEntryPoint(
     }
 }
 
-private fun changeLocale(languageCode: String, context: Context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        context.getSystemService(LocaleManager::class.java)
-            .applicationLocales = LocaleList.forLanguageTags(languageCode)
-    } else {
-        AppCompatDelegate.setApplicationLocales(
-            LocaleListCompat.forLanguageTags(languageCode)
-        )
-    }
-}
-
 @Composable
 private fun SettingsScreen(
     state: SettingsUiState,
     onChapterClick: (Chapter) -> Unit,
-    onLanguageSelected: (Language) -> Unit,
-    onApplyClick: (Language) -> Unit,
+    onChangeLanguageClick: () -> Unit,
     onNotificationToggle: (Boolean) -> Unit
 ) {
     val colors = LocalColors.current
@@ -134,41 +108,10 @@ private fun SettingsScreen(
                     .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                H3Text(
-                    text = stringResource(R.string.select_language)
-                )
-
-                Language.entries.forEach { language ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        RadioButton(
-                            selected = state.selectedLanguage == language,
-                            onClick = { onLanguageSelected(language) },
-                            colors = RadioButtonDefaults.colors().copy(
-                                selectedColor = colors.primary
-                            )
-                        )
-                        H3Text(
-                            modifier = Modifier.padding(start = 8.dp),
-                            text = language.displayName
-                        )
-                    }
-                }
                 PrimaryButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 16.dp),
-                    text = stringResource(R.string.apply),
-                    onClick = { onApplyClick(state.selectedLanguage) }
-                )
-
-                H3Text(
-                    modifier = Modifier.padding(top = 24.dp),
-                    text = stringResource(R.string.enable_notifications)
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(R.string.change_language),
+                    onClick = onChangeLanguageClick
                 )
 
                 Row(

--- a/settings/src/main/java/com/firdavs/persianliterature/settings/SettingsViewModel.kt
+++ b/settings/src/main/java/com/firdavs/persianliterature/settings/SettingsViewModel.kt
@@ -2,35 +2,18 @@ package com.firdavs.persianliterature.settings
 
 import android.app.Application
 import com.firdavs.persianliterature.core.presentation.BaseViewModel
-import com.firdavs.persianliterature.settings.api.Language
-import com.firdavs.persianliterature.settings.api.LanguageManager
 import com.firdavs.persianliterature.settings.api.NotificationManager
 
 class SettingsViewModel(
     private val application: Application,
-    private val languageManager: LanguageManager,
     private val notificationManager: NotificationManager
 ) : BaseViewModel<SettingsUiState>(SettingsUiState()) {
 
     init {
-        val savedLanguage = languageManager.getSavedLanguage(application)
         val notificationsEnabled = notificationManager.isNotificationEnabled(application)
         post {
-            it.copy(
-                selectedLanguage = savedLanguage,
-                notificationsEnabled = notificationsEnabled
-            )
+            it.copy(notificationsEnabled = notificationsEnabled)
         }
-    }
-
-    fun onLanguageSelected(language: Language) {
-        post {
-            it.copy(selectedLanguage = language)
-        }
-    }
-
-    fun onApplyClick(language: Language) {
-        languageManager.setLanguage(application, language)
     }
 
     fun onNotificationToggle(enabled: Boolean) {

--- a/settings/src/main/res/values-ru/strings.xml
+++ b/settings/src/main/res/values-ru/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="select_language">Выберите язык</string>
     <string name="apply">Применить</string>
+    <string name="change_language">Изменить язык</string>
 
     <!-- Notification Strings -->
     <string name="enable_notifications">Включить ежедневные уведомления</string>

--- a/settings/src/main/res/values-tg/strings.xml
+++ b/settings/src/main/res/values-tg/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="select_language">Забонро интихоб кунед</string>
     <string name="apply">Татбиқ кунед</string>
+    <string name="change_language">Забонро тағйир диҳед</string>
 
     <!-- Notification Strings -->
     <string name="enable_notifications">Фаъол кардани огоҳиҳои ҳаррӯза</string>

--- a/settings/src/main/res/values/strings.xml
+++ b/settings/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="select_language">Select Language</string>
     <string name="apply">Apply</string>
+    <string name="change_language">Change Language</string>
 
     <!-- Notification Strings -->
     <string name="enable_notifications">Enable Daily Notifications</string>


### PR DESCRIPTION
## Summary

Redesigned the Settings screen according to issue #35:

1. Added "Change language" button in SettingsScreen that navigates to a new screen for changing language
2. Removed inline language selection functionality from SettingsScreen
3. Removed H3Text header for notifications section, keeping only the toggle row

## Changes

- Created new LanguageScreen with ViewModel and UiState
- Added navigation route and wired up navigation
- Simplified SettingsScreen UI
- Updated ViewModels and state classes
- Added localized strings for all 3 languages (en, ru, tg)

Resolves #35

Generated with [Claude Code](https://claude.ai/code)