### PR TITLE
feat: use random author data for push notifications

### DIFF
--- a/author/src/main/java/com/firdavs/persianliterature/author/db/dao/AuthorsDao.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/dao/AuthorsDao.kt
@@ -31,4 +31,7 @@ interface AuthorsDao {
 
     @Query("SELECT id FROM ${AuthorsDb.AUTHORS} WHERE isFavourite = 1")
     suspend fun getFavouriteIds(): List<String>
+
+    @Query("SELECT * FROM ${AuthorsDb.AUTHORS} ORDER BY RANDOM() LIMIT 1")
+    suspend fun getRandomAuthor(): AuthorEntity?
 }

--- a/settings/build.gradle
+++ b/settings/build.gradle
@@ -8,5 +8,6 @@ dependencies {
     implementation module.settings_api
     implementation module.core
     implementation module.ui_kit
+    implementation module.author
     implementation library.work_runtime
 }

--- a/settings/build.gradle
+++ b/settings/build.gradle
@@ -10,4 +10,5 @@ dependencies {
     implementation module.ui_kit
     implementation module.author
     implementation library.work_runtime
+    implementation library.room_runtime
 }

--- a/settings/src/main/java/com/firdavs/persianliterature/settings/DailyNotificationWorker.kt
+++ b/settings/src/main/java/com/firdavs/persianliterature/settings/DailyNotificationWorker.kt
@@ -12,12 +12,14 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.firdavs.persianliterature.author.db.AuthorsDb
 import com.firdavs.persianliterature.settings.api.NotificationManager as NotificationManagerApi
 
 class DailyNotificationWorker(
     private val context: Context,
     params: WorkerParameters,
-    private val notificationManager: NotificationManagerApi
+    private val notificationManager: NotificationManagerApi,
+    private val authorsDb: AuthorsDb
 ) : CoroutineWorker(context, params) {
 
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
@@ -48,7 +50,10 @@ class DailyNotificationWorker(
     }
 
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
-    private fun showNotification() {
+    private suspend fun showNotification() {
+        // Get a random author from the database
+        val randomAuthor = authorsDb.getAuthorsDao().getRandomAuthor()
+
         val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
@@ -66,10 +71,14 @@ class DailyNotificationWorker(
             pendingIntentFlags
         )
 
+        // Use random author data if available, otherwise use default strings
+        val notificationTitle = randomAuthor?.name ?: context.getString(R.string.notification_title)
+        val notificationText = randomAuthor?.place ?: context.getString(R.string.notification_text)
+
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
-            .setContentTitle(context.getString(R.string.notification_title))
-            .setContentText(context.getString(R.string.notification_text))
+            .setContentTitle(notificationTitle)
+            .setContentText(notificationText)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)


### PR DESCRIPTION
Updates push notification to use random author data from AuthorsDb.

## Changes
- Added `getRandomAuthor()` query to AuthorsDao
- Modified DailyNotificationWorker to inject AuthorsDb and fetch random author
- Notification title now shows author's name
- Notification description now shows author's birthplace
- Added author module dependency to settings module
- Falls back to default strings if database is empty

Closes #36

Generated with [Claude Code](https://claude.ai/code)