### PR TITLE
feat: add splash screen with app icon and primary color background

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
     implementation library.activity_compose
     implementation library.appcompat
+    implementation library.splash_screen
     implementation platform(library.firebase_bom)
     implementation library.firestore_ktx
     implementation groups.navigation

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop"
-            android:theme="@style/Theme.PersianLiterature">
+            android:theme="@style/Theme.PersianLiterature.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -26,6 +27,9 @@ class MainActivity : ComponentActivity() {
     private var notificationPoemId by mutableStateOf<String?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Install splash screen before calling super.onCreate()
+        installSplashScreen()
+
         super.onCreate(savedInstanceState)
 
         // Handle initial intent

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="gold">#FFE5B973</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,4 +4,10 @@
     <style name="Theme.PersianLiterature" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
     </style>
+
+    <style name="Theme.PersianLiterature.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/gold</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/Theme.PersianLiterature</item>
+    </style>
 </resources>

--- a/gradle/scripts/dependencies-versions.gradle
+++ b/gradle/scripts/dependencies-versions.gradle
@@ -21,4 +21,5 @@ ext {
     pdf_viewer_version = "2.3.7"
     media3_version = "1.5.0"
     work_version = "2.10.0"
+    splash_screen_version = "1.0.1"
 }

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -57,7 +57,8 @@ ext {
             media3_session         : ("androidx.media3:media3-session:$media3_version"),
             media3_ui              : ("androidx.media3:media3-ui:$media3_version"),
 
-            work_runtime           : ("androidx.work:work-runtime-ktx:$work_version")
+            work_runtime           : ("androidx.work:work-runtime-ktx:$work_version"),
+            splash_screen          : ("androidx.core:core-splashscreen:$splash_screen_version")
     ]
     module = [
             core            : project(":core"),


### PR DESCRIPTION
## Summary
Adds a native splash screen to the Persian Literature app with the app icon centered and primary color background.

## Changes
- Added Gold color (#FFE5B973) to colors.xml
- Created splash screen theme configuration
- Added androidx.core:core-splashscreen:1.0.1 dependency
- Integrated splash screen in MainActivity
- Updated manifest to use splash screen theme

## Testing
The splash screen will appear when launching the app, displaying the app icon on a gold background before transitioning to the main content.

Closes #42

Generated with [Claude Code](https://claude.ai/code)