### PR TITLE
feat: add language selection dialog on first app launch

### DIFF
--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/LanguageSelectionDialog.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/LanguageSelectionDialog.kt
@@ -1,0 +1,101 @@
+package com.firdavs.persianliterature.app.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.firdavs.persianliterature.settings.api.Language
+import com.firdavs.persianliterature.ui.kit.theme.AppTheme
+
+@Composable
+fun LanguageSelectionDialog(
+    onLanguageSelected: (Language) -> Unit
+) {
+    Dialog(onDismissRequest = { /* Prevent dismissing without selection */ }) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = AppTheme.colors.surface
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // Title in all three languages
+                Text(
+                    text = "Choose Language / Выберите язык / Забонро интихоб кунед",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = AppTheme.colors.onSurface,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // English button
+                TextButton(
+                    onClick = { onLanguageSelected(Language.ENGLISH) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "English",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = AppTheme.colors.primary
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Russian button
+                TextButton(
+                    onClick = { onLanguageSelected(Language.RUSSIAN) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "Русский",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = AppTheme.colors.primary
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Tajik button
+                TextButton(
+                    onClick = { onLanguageSelected(Language.TAJIK) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "Тоҷикӣ",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = AppTheme.colors.primary
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivity.kt
@@ -95,6 +95,14 @@ class MainActivity : ComponentActivity() {
                                 onDismiss = { viewModel.dismissWelcomeDialog() }
                             )
                         }
+
+                        if (state.showLanguageSelectionDialog) {
+                            LanguageSelectionDialog(
+                                onLanguageSelected = { language ->
+                                    viewModel.onLanguageSelected(language)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivityUiState.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivityUiState.kt
@@ -5,5 +5,6 @@ import com.firdavs.persianliterature.core.presentation.UiState
 data class MainActivityUiState(
     val notificationPoemId: String? = null,
     val showWelcomeDialog: Boolean = false,
+    val showLanguageSelectionDialog: Boolean = false,
     val requestNotificationPermission: Boolean = false
 ) : UiState()

--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainViewModel.kt
@@ -29,11 +29,6 @@ class MainViewModel(
 
     init {
         checkFirstLaunch()
-        fetchAuthors()
-        fetchWorks()
-        fetchQuizzes()
-        fetchQuestions()
-        fetchPoems()
     }
 
     private fun checkFirstLaunch() {
@@ -118,6 +113,11 @@ class MainViewModel(
     fun onLanguageSelected(language: Language) {
         // Set the selected language
         languageManager.setLanguage(application, language)
+        fetchAuthors()
+        fetchWorks()
+        fetchQuizzes()
+        fetchQuestions()
+        fetchPoems()
 
         // Dismiss the language selection dialog
         post { it.copy(showLanguageSelectionDialog = false, requestNotificationPermission = true) }

--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainViewModel.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainViewModel.kt
@@ -41,10 +41,7 @@ class MainViewModel(
         val isFirstLaunch = prefs.getBoolean(KEY_FIRST_LAUNCH, true)
 
         if (isFirstLaunch) {
-            languageManager.setLanguage(application, Language.TAJIK)
-            post { it.copy(showWelcomeDialog = true, requestNotificationPermission = true) }
-
-            prefs.edit { putBoolean(KEY_FIRST_LAUNCH, false) }
+            post { it.copy(showLanguageSelectionDialog = true) }
         }
     }
 
@@ -116,6 +113,18 @@ class MainViewModel(
 
     fun dismissWelcomeDialog() {
         post { it.copy(showWelcomeDialog = false) }
+    }
+
+    fun onLanguageSelected(language: Language) {
+        // Set the selected language
+        languageManager.setLanguage(application, language)
+
+        // Dismiss the language selection dialog
+        post { it.copy(showLanguageSelectionDialog = false, requestNotificationPermission = true) }
+
+        // Mark first launch as completed
+        val prefs = application.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        prefs.edit { putBoolean(KEY_FIRST_LAUNCH, false) }
     }
 
     companion object {


### PR DESCRIPTION
Changed first launch behavior to show a language selection dialog instead of automatically selecting Tajik language. Users can now choose between English, Russian, and Tajik on their first app launch.

Fixes #44

Generated with [Claude Code](https://claude.ai/code)