### PR TITLE
Implement sequential poem navigation with previous/next buttons

### DIFF
--- a/author/src/main/java/com/firdavs/persianliterature/author/db/dao/PoemsDao.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/db/dao/PoemsDao.kt
@@ -24,4 +24,7 @@ interface PoemsDao {
 
     @Query("SELECT * FROM ${AuthorsDb.POEMS}")
     fun getAllFlow(): Flow<List<PoemEntity>>
+
+    @Query("SELECT * FROM ${AuthorsDb.POEMS}")
+    suspend fun getAllPoems(): List<PoemEntity>
 }

--- a/author/src/main/java/com/firdavs/persianliterature/author/repository/PoemRepositoryImpl.kt
+++ b/author/src/main/java/com/firdavs/persianliterature/author/repository/PoemRepositoryImpl.kt
@@ -38,4 +38,8 @@ class PoemRepositoryImpl(
     override suspend fun getPoemById(id: String): Poem? {
         return poemsDao.getPoemById(id)?.toDomain()
     }
+
+    override suspend fun getAllPoems(): List<Poem> {
+        return poemsDao.getAllPoems().map { it.toDomain() }
+    }
 }

--- a/author_api/src/main/java/com/firdavs/persianliterature/author_api/repository/PoemRepository.kt
+++ b/author_api/src/main/java/com/firdavs/persianliterature/author_api/repository/PoemRepository.kt
@@ -6,4 +6,5 @@ interface PoemRepository {
     suspend fun fetchPoems()
     suspend fun getRandomPoem(): Poem?
     suspend fun getPoemById(id: String): Poem?
+    suspend fun getAllPoems(): List<Poem>
 }

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -53,6 +55,7 @@ fun PoemOfDayEntryPoint(
             onChapterClick = onChapterClick,
             onRefreshClick = viewModel::onRefreshClick,
             onNewPoemClick = viewModel::onNewPoemClick,
+            onPreviousPoemClick = viewModel::onPreviousPoemClick,
             resetShowToastFlag = viewModel::resetShowToastFlag
         )
     }
@@ -64,6 +67,7 @@ private fun PoemOfDayScreen(
     onChapterClick: (Chapter) -> Unit,
     onRefreshClick: () -> Unit,
     onNewPoemClick: () -> Unit,
+    onPreviousPoemClick: () -> Unit,
     resetShowToastFlag: () -> Unit
 ) {
     val context = localizedContext()
@@ -180,11 +184,21 @@ private fun PoemOfDayScreen(
                         }
                     }
                     Spacer(modifier = Modifier.height(24.dp))
-                    PrimaryButton(
-                        text = stringResource(R.string.new_poem),
-                        enabled = !state.isLoading,
-                        onClick = onNewPoemClick
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
+                    ) {
+                        PrimaryButton(
+                            text = stringResource(R.string.previous_poem),
+                            enabled = !state.isLoading && state.allPoems.isNotEmpty(),
+                            onClick = onPreviousPoemClick
+                        )
+                        PrimaryButton(
+                            text = stringResource(R.string.new_poem),
+                            enabled = !state.isLoading && state.allPoems.isNotEmpty(),
+                            onClick = onNewPoemClick
+                        )
+                    }
                 }
             } else {
                 Box(

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -26,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.firdavs.persianliterature.ui.kit.theme.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -41,6 +39,7 @@ import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
 import com.firdavs.persianliterature.ui.kit.components.buttons.PrimaryButton
 import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 import com.firdavs.persianliterature.ui.kit.theme.localizedContext
+import com.firdavs.persianliterature.ui.kit.theme.stringResource
 import kotlinx.coroutines.launch
 import com.firdavs.persianliterature.core.R as UiR
 
@@ -186,16 +185,22 @@ private fun PoemOfDayScreen(
                     Spacer(modifier = Modifier.height(24.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         PrimaryButton(
+                            modifier = Modifier.weight(1f),
                             text = stringResource(R.string.previous_poem),
                             enabled = !state.isLoading && state.allPoems.isNotEmpty(),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                             onClick = onPreviousPoemClick
                         )
                         PrimaryButton(
+                            modifier = Modifier.weight(1f),
                             text = stringResource(R.string.new_poem),
                             enabled = !state.isLoading && state.allPoems.isNotEmpty(),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                             onClick = onNewPoemClick
                         )
                     }

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayUiState.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayUiState.kt
@@ -6,6 +6,8 @@ import com.firdavs.persianliterature.core.presentation.UiState
 
 data class PoemOfDayUiState(
     val poem: Poem? = null,
+    val allPoems: List<Poem> = emptyList(),
+    val currentIndex: Int = -1,
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
     val showToast: Boolean = false,

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayViewModel.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayViewModel.kt
@@ -17,12 +17,19 @@ class PoemOfDayViewModel(
 
     private fun loadPoem() {
         viewModelScope.launch {
-            val poem = if (poemId != null) {
-                poemRepository.getPoemById(poemId)
+            if (poemId != null) {
+                val poem = poemRepository.getPoemById(poemId)
+                post { it.copy(poem = poem, isLoading = false) }
             } else {
-                poemRepository.getRandomPoem()
+                val allPoems = poemRepository.getAllPoems()
+                if (allPoems.isNotEmpty()) {
+                    val randomIndex = allPoems.indices.random()
+                    val poem = allPoems[randomIndex]
+                    post { it.copy(poem = poem, allPoems = allPoems, currentIndex = randomIndex, isLoading = false) }
+                } else {
+                    post { it.copy(isLoading = false) }
+                }
             }
-            post { it.copy(poem = poem, isLoading = false) }
         }
     }
 
@@ -41,10 +48,32 @@ class PoemOfDayViewModel(
     }
 
     fun onNewPoemClick() {
-        post { it.copy(isLoading = true) }
-        viewModelScope.launch {
-            val poem = poemRepository.getRandomPoem()
-            post { it.copy(poem = poem, isLoading = false) }
+        post { currentState ->
+            val allPoems = currentState.allPoems
+            if (allPoems.isEmpty()) {
+                currentState
+            } else {
+                val nextIndex = (currentState.currentIndex + 1) % allPoems.size
+                val nextPoem = allPoems[nextIndex]
+                currentState.copy(poem = nextPoem, currentIndex = nextIndex)
+            }
+        }
+    }
+
+    fun onPreviousPoemClick() {
+        post { currentState ->
+            val allPoems = currentState.allPoems
+            if (allPoems.isEmpty()) {
+                currentState
+            } else {
+                val previousIndex = if (currentState.currentIndex - 1 < 0) {
+                    allPoems.size - 1
+                } else {
+                    currentState.currentIndex - 1
+                }
+                val previousPoem = allPoems[previousIndex]
+                currentState.copy(poem = previousPoem, currentIndex = previousIndex)
+            }
         }
     }
 

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayViewModel.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayViewModel.kt
@@ -17,11 +17,12 @@ class PoemOfDayViewModel(
 
     private fun loadPoem() {
         viewModelScope.launch {
+            val allPoems = poemRepository.getAllPoems()
             if (poemId != null) {
                 val poem = poemRepository.getPoemById(poemId)
-                post { it.copy(poem = poem, isLoading = false) }
+                val currentIndex = allPoems.indexOfFirst { it.id == poemId }
+                post { it.copy(poem = poem, allPoems = allPoems, currentIndex = currentIndex, isLoading = false) }
             } else {
-                val allPoems = poemRepository.getAllPoems()
                 if (allPoems.isNotEmpty()) {
                     val randomIndex = allPoems.indices.random()
                     val poem = allPoems[randomIndex]

--- a/poem_of_day/src/main/res/values-ru/strings.xml
+++ b/poem_of_day/src/main/res/values-ru/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="poems_refreshed">Стихи успешно обновлены</string>
     <string name="new_poem">Новый стих</string>
+    <string name="previous_poem">Предыдущий стих</string>
     <string name="no_poems_available">Стихи пока недоступны</string>
 </resources>

--- a/poem_of_day/src/main/res/values-tg/strings.xml
+++ b/poem_of_day/src/main/res/values-tg/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="poems_refreshed">Шеърҳо бомуваффақият навсозӣ шуданд</string>
     <string name="new_poem">Шеъри нав</string>
+    <string name="previous_poem">Шеъри пешин</string>
     <string name="no_poems_available">Шеърҳо ҳанӯз дастрас нестанд</string>
 </resources>

--- a/poem_of_day/src/main/res/values/strings.xml
+++ b/poem_of_day/src/main/res/values/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="poems_refreshed">Poems refreshed successfully</string>
     <string name="new_poem">New Poem</string>
+    <string name="previous_poem">Previous Poem</string>
     <string name="no_poems_available">No poems available yet</string>
 </resources>

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/Text.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/Text.kt
@@ -36,15 +36,17 @@ fun H4Text(
     text: String,
     modifier: Modifier = Modifier,
     color: Color? = null,
-    textAlign: TextAlign? = null
+    textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip
 ) =
     AppTheme.typography.h4TextStyle.asText(
         text,
         modifier,
         color,
         textAlign,
-        Int.MAX_VALUE,
-        TextOverflow.Clip
+        maxLines,
+        overflow
     )
 
 @Composable
@@ -166,15 +168,17 @@ fun H4Text(
     @StringRes res: Int,
     modifier: Modifier = Modifier,
     color: Color? = null,
-    textAlign: TextAlign? = null
+    textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip
 ) =
     AppTheme.typography.h4TextStyle.asText(
         stringResource(res),
         modifier,
         color,
         textAlign,
-        Int.MAX_VALUE,
-        TextOverflow.Clip
+        maxLines,
+        overflow
     )
 
 @Composable

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/buttons/PrimaryButton.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/components/buttons/PrimaryButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import com.firdavs.persianliterature.ui.kit.H4Text
 import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 
@@ -21,6 +22,8 @@ fun PrimaryButton(
         disabledContentColor = LocalColors.current.onPrimary,
         disabledContainerColor = LocalColors.current.outline
     ),
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
     onClick: () -> Unit
 ) {
     Button(
@@ -30,6 +33,10 @@ fun PrimaryButton(
         colors = buttonColors,
         onClick = onClick
     ) {
-        H4Text(text = text)
+        H4Text(
+            text = text,
+            maxLines = maxLines,
+            overflow = overflow
+        )
     }
 }


### PR DESCRIPTION
Implements sequential navigation for the Poem of the Day screen as requested in issue #49.

### Changes
- Added repository methods to fetch all poems from database
- Updated state management to track all poems and current index
- Modified navigation logic to support sequential browsing with wrap-around
- Added "Previous Poem" button alongside existing "New Poem" button
- Included string resources for all supported languages (en, ru, tg)

Fixes #49

Generated with [Claude Code](https://claude.ai/code)