### PR TITLE
feat: Add answer confirmation phase to QuizPlayScreen

### DIFF
--- a/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayScreen.kt
+++ b/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayScreen.kt
@@ -276,7 +276,7 @@ private fun OptionCard(
     val backgroundColor = when {
         showCorrect -> colors.tertiary.copy(alpha = 0.3f)
         showIncorrect -> colors.error.copy(alpha = 0.3f)
-        isSelected -> colors.secondary.copy(alpha = 0.5f)
+        isSelected -> colors.primary
         else -> colors.primary.copy(alpha = 0.3f)
     }
 

--- a/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayScreen.kt
+++ b/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayScreen.kt
@@ -57,6 +57,7 @@ fun QuizPlayEntryPoint(
             state = state,
             onBackClick = onBackClick,
             onAnswerSelected = viewModel::onAnswerSelected,
+            onConfirmAnswer = viewModel::onConfirmAnswer,
             onNextQuestion = viewModel::onNextQuestion,
             onShowQuitDialog = viewModel::onShowQuitDialog,
             onDismissQuitDialog = viewModel::onDismissQuitDialog
@@ -70,6 +71,7 @@ private fun QuizPlayScreen(
     state: QuizPlayUiState,
     onBackClick: () -> Unit,
     onAnswerSelected: (String) -> Unit,
+    onConfirmAnswer: () -> Unit,
     onNextQuestion: () -> Unit,
     onShowQuitDialog: () -> Unit,
     onDismissQuitDialog: () -> Unit
@@ -116,10 +118,13 @@ private fun QuizPlayScreen(
 
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     currentQuestion.options.forEach { option ->
-                        val isSelected = state.userAnswers[currentQuestion.id] == option
+                        val confirmedAnswer = state.userAnswers[currentQuestion.id]
+                        val isConfirmed = confirmedAnswer == option
+                        val isSelectedButNotConfirmed = state.selectedButUnconfirmedAnswer == option
+                        val isSelected = isConfirmed || isSelectedButNotConfirmed
                         val isCorrect = option == currentQuestion.correctAnswer
                         val showCorrect = state.showExplanation && isCorrect
-                        val showIncorrect = state.showExplanation && isSelected && !isCorrect
+                        val showIncorrect = state.showExplanation && isConfirmed && !isCorrect
 
                         OptionCard(
                             text = option,
@@ -130,6 +135,15 @@ private fun QuizPlayScreen(
                             onClick = { onAnswerSelected(option) }
                         )
                     }
+                }
+
+                if (!state.showExplanation && state.selectedButUnconfirmedAnswer != null) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    PrimaryButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = stringResource(R.string.confirm_answer),
+                        onClick = onConfirmAnswer
+                    )
                 }
 
                 if (state.showExplanation) {

--- a/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayUiState.kt
+++ b/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayUiState.kt
@@ -9,6 +9,7 @@ data class QuizPlayUiState(
     val questions: List<Question> = emptyList(),
     val currentQuestionIndex: Int = 0,
     val userAnswers: Map<String, String> = emptyMap(),
+    val selectedButUnconfirmedAnswer: String? = null,
     val showExplanation: Boolean = false,
     val isSubmitted: Boolean = false,
     val progressId: String? = null,

--- a/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayViewModel.kt
+++ b/quiz_ui/src/main/java/com/firdavs/persianliterature/quiz/ui/play/QuizPlayViewModel.kt
@@ -42,9 +42,20 @@ class QuizPlayViewModel(
     }
 
     fun onAnswerSelected(answer: String) {
+        post { it.copy(selectedButUnconfirmedAnswer = answer) }
+    }
+
+    fun onConfirmAnswer() {
         val currentQuestion = state.value.currentQuestion ?: return
-        val updatedAnswers = state.value.userAnswers + (currentQuestion.id to answer)
-        post { it.copy(userAnswers = updatedAnswers, showExplanation = true) }
+        val selectedAnswer = state.value.selectedButUnconfirmedAnswer ?: return
+        val updatedAnswers = state.value.userAnswers + (currentQuestion.id to selectedAnswer)
+        post {
+            it.copy(
+                userAnswers = updatedAnswers,
+                showExplanation = true,
+                selectedButUnconfirmedAnswer = null
+            )
+        }
     }
 
     fun onNextQuestion() {
@@ -54,6 +65,7 @@ class QuizPlayViewModel(
                 it.copy(
                     currentQuestionIndex = nextIndex,
                     showExplanation = false,
+                    selectedButUnconfirmedAnswer = null,
                     questionStartTime = System.currentTimeMillis()
                 )
             }

--- a/quiz_ui/src/main/res/values-ru/strings.xml
+++ b/quiz_ui/src/main/res/values-ru/strings.xml
@@ -6,6 +6,7 @@
     <string name="your_best_score">Лучший результат: %d%%</string>
     <string name="question_progress">Вопрос %1$d из %2$d</string>
     <string name="submit_answer">Отправить ответ</string>
+    <string name="confirm_answer">Подтвердить ответ</string>
     <string name="next_question">Следующий вопрос</string>
     <string name="finish_quiz">Завершить викторину</string>
     <string name="quiz_results">Результаты викторины</string>

--- a/quiz_ui/src/main/res/values-tg/strings.xml
+++ b/quiz_ui/src/main/res/values-tg/strings.xml
@@ -6,6 +6,7 @@
     <string name="your_best_score">Беҳтарин натиҷа: %d%%</string>
     <string name="question_progress">Савол %1$d аз %2$d</string>
     <string name="submit_answer">Фиристодани ҷавоб</string>
+    <string name="confirm_answer">Тасдиқи ҷавоб</string>
     <string name="next_question">Саволи навбатӣ</string>
     <string name="finish_quiz">Анҷоми имтиҳон</string>
     <string name="quiz_results">Натиҷаҳои имтиҳон</string>

--- a/quiz_ui/src/main/res/values/strings.xml
+++ b/quiz_ui/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="your_best_score">Best: %d%%</string>
     <string name="question_progress">Question %1$d of %2$d</string>
     <string name="submit_answer">Submit Answer</string>
+    <string name="confirm_answer">Confirm Answer</string>
     <string name="next_question">Next Question</string>
     <string name="finish_quiz">Finish Quiz</string>
     <string name="quiz_results">Quiz Results</string>


### PR DESCRIPTION
Add a two-step answer selection process where users must confirm their selected answer before it's submitted. This prevents accidental submissions and gives users a chance to review their choice.

## Changes
- Added selectedButUnconfirmedAnswer state field to track selection
- Updated onAnswerSelected() to only mark answer as selected
- Added onConfirmAnswer() method to confirm and lock in the answer
- Added "Confirm Answer" button in UI when option is selected
- Added localized strings for confirm button (en, ru, tg)
- Updated option highlighting to distinguish selected vs confirmed

Fixes #47

Generated with [Claude Code](https://claude.ai/code)