### PR TITLE
Change audio book time format from mm:ss to hh:mm:ss

### DIFF
--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -406,11 +406,13 @@ fun AudioControlsSection(
 @SuppressLint("DefaultLocale", "ImplicitDefaultLocale")
 private fun formatTime(milliseconds: Long): String {
     val totalSeconds = milliseconds / MILLIS_IN_SECOND
-    val minutes = totalSeconds / SECONDS_IN_MINUTE
+    val hours = totalSeconds / SECONDS_IN_HOUR
+    val minutes = (totalSeconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE
     val seconds = totalSeconds % SECONDS_IN_MINUTE
-    return String.format("%d:%02d", minutes, seconds)
+    return String.format("%d:%02d:%02d", hours, minutes, seconds)
 }
 
 private const val SECONDS_IN_MINUTE = 60
+private const val SECONDS_IN_HOUR = 3600
 private const val MILLIS_IN_SECOND = 1000
 private const val FULL_PERCENT = 100

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -409,7 +409,7 @@ private fun formatTime(milliseconds: Long): String {
     val hours = totalSeconds / SECONDS_IN_HOUR
     val minutes = (totalSeconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE
     val seconds = totalSeconds % SECONDS_IN_MINUTE
-    return String.format("%d:%02d:%02d", hours, minutes, seconds)
+    return String.format("%02d:%02d:%02d", hours, minutes, seconds)
 }
 
 private const val SECONDS_IN_MINUTE = 60


### PR DESCRIPTION
Updated the formatTime function in WorkDetailsScreen to display audiobook length in hh:mm:ss format instead of mm:ss format.

Changes:
- Added hours calculation
- Updated format string to include hours
- Added SECONDS_IN_HOUR constant

Fixes #54

Generated with [Claude Code](https://claude.ai/code)