### PR TITLE
fix: move Chapter.AboutApp to end of left drawer

### DIFF
--- a/core/src/main/java/com/firdavs/persianliterature/core/model/Chapter.kt
+++ b/core/src/main/java/com/firdavs/persianliterature/core/model/Chapter.kt
@@ -13,6 +13,6 @@ enum class Chapter(val titleRes: Int) {
     Settings(R.string.settings);
 
     companion object {
-        val all = listOf(Authors, AllWorks, PoemOfDay, AudioBooks, Quiz, AboutApp, Favourites, Settings)
+        val all = listOf(Authors, AllWorks, PoemOfDay, AudioBooks, Quiz, Favourites, Settings, AboutApp)
     }
 }


### PR DESCRIPTION
Move Chapter.AboutApp to the end of the left drawer by reordering the Chapter.all list.

Closes #62

Generated with [Claude Code](https://claude.ai/code)