### PR TITLE
fix: loader not showing on first launch

### DIFF
--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/list/AuthorsListViewModel.kt
@@ -25,9 +25,13 @@ class AuthorsListViewModel(
 
     private fun observeAuthors() {
         viewModelScope.launch {
+            var firstEmission = true
             authorRepository.getAuthors().collect { authors ->
                 allAuthors = authorUiMapper.map(authors)
-                post { it.copy(authors = allAuthors, isLoading = false) }
+                // Keep loading if the first DB emission is empty (first launch, data not yet fetched from server).
+                val stillLoading = firstEmission && authors.isEmpty()
+                post { it.copy(authors = allAuthors, isLoading = stillLoading) }
+                firstEmission = false
             }
         }
     }


### PR DESCRIPTION
Fixes #61

On first launch, Room DB is empty so `AuthorsListViewModel.observeAuthors()` receives an empty list immediately, setting `isLoading = false` before Firebase data arrives. After language selection the screen was visible with no spinner despite data still being fetched.

Track the first DB emission: if it is empty, keep `isLoading = true` until a non-empty list arrives.

Generated with [Claude Code](https://claude.ai/code)