### PR TITLE
fix: fix Card height and add scroll in PoemOfDayScreen

### DIFF
--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -148,6 +148,10 @@ private fun PoemOfDayScreen(
                         .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
+                    val scrollState = rememberScrollState()
+                    LaunchedEffect(state.poem) {
+                        scrollState.scrollTo(0)
+                    }
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -160,7 +164,7 @@ private fun PoemOfDayScreen(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .verticalScroll(rememberScrollState())
+                                .verticalScroll(scrollState)
                                 .padding(24.dp),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -145,13 +145,13 @@ private fun PoemOfDayScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
                         .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
                 ) {
                     Card(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
                         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
                         colors = CardDefaults.cardColors(
                             containerColor = LocalColors.current.surface
@@ -160,6 +160,7 @@ private fun PoemOfDayScreen(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .verticalScroll(rememberScrollState())
                                 .padding(24.dp),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {


### PR DESCRIPTION
Fix the height of Card in PoemOfDayScreen to fill available space and add vertical scroll for long poems.

Closes #60

Generated with [Claude Code](https://claude.ai/code)