### PR TITLE
feat: implement edge-to-edge design

### DIFF
--- a/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/firdavs/persianliterature/app/ui/MainActivity.kt
@@ -7,8 +7,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -32,9 +34,8 @@ class MainActivity : ComponentActivity() {
     private lateinit var viewModel: MainViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Install splash screen before calling super.onCreate()
         installSplashScreen()
-
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         // Handle initial intent
@@ -83,7 +84,8 @@ class MainActivity : ComponentActivity() {
                 CompositionLocalProvider(LocalAppLocale provides currentLocale) {
                     Scaffold(
                         modifier = Modifier.fillMaxSize(),
-                        containerColor = AppTheme.colors.background
+                        containerColor = AppTheme.colors.background,
+                        contentWindowInsets = WindowInsets(0, 0, 0, 0)
                     ) { innerPadding ->
                         Navigator(
                             state = state,

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/BaseScreen.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/BaseScreen.kt
@@ -1,11 +1,15 @@
 package com.firdavs.persianliterature.ui.kit
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,8 +49,14 @@ fun BaseScreen(
             modifier = modifier.fillMaxSize(),
             containerColor = backgroundColor,
             topBar = {
-                topBar?.let {
-                    topBar(drawerState, scope)
+                topBar?.let { topBarContent ->
+                    Box(
+                        modifier = Modifier
+                            .background(LocalColors.current.primary)
+                            .windowInsetsPadding(WindowInsets.statusBars)
+                    ) {
+                        topBarContent(drawerState, scope)
+                    }
                 }
             },
             content = { innerPadding ->
@@ -55,7 +65,10 @@ fun BaseScreen(
                         modifier = Modifier
                             .weight(1f)
                             .fillMaxWidth()
-                            .padding(top = if (applyTopPadding) innerPadding.calculateTopPadding() else 0.dp)
+                            .padding(
+                                top = if (applyTopPadding) innerPadding.calculateTopPadding() else 0.dp,
+                                bottom = if (footerContent == null) innerPadding.calculateBottomPadding() else 0.dp
+                            )
                             .thenIfNotNull(footerContent) { drawShadow() }
                     ) {
                         mainContent()
@@ -64,7 +77,8 @@ fun BaseScreen(
                     if (footerContent != null) {
                         Box(
                             modifier = Modifier
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .padding(bottom = innerPadding.calculateBottomPadding()),
                             content = footerContent
                         )
                     }

--- a/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/theme/Theme.kt
+++ b/ui_kit/src/main/java/com/firdavs/persianliterature/ui/kit/theme/Theme.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -80,7 +79,6 @@ private fun BaseTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }
     }


### PR DESCRIPTION
Implements edge-to-edge design so app content extends behind the status bar and navigation bar.

**Changes:**
- `MainActivity`: call `enableEdgeToEdge()`, set outer Scaffold contentWindowInsets to zero
- `Theme.kt`: remove `statusBarColor` override that conflicted with transparent status bar
- `BaseScreen.kt`: wrap topBar slot with primary background + statusBars insets; apply navigation bar insets to content and footer

Closes #70

Generated with [Claude Code](https://claude.ai/code)