### PR TITLE
feat: add share poem of day as screenshot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,16 @@
             </intent-filter>
         </service>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <!-- Disable WorkManager auto-initialization to allow manual initialization with Koin -->
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="shared_images" path="." />
+</paths>

--- a/poem_of_day/build.gradle
+++ b/poem_of_day/build.gradle
@@ -8,4 +8,5 @@ dependencies {
     implementation module.core
     implementation module.ui_kit
     implementation module.author_api
+    implementation library.core_ktx
 }

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -1,6 +1,5 @@
 package com.firdavs.persianliterature.poem_of_day
 
-import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import androidx.compose.foundation.background
@@ -86,6 +85,13 @@ private fun PoemOfDayScreen(
     val graphicsLayer = rememberGraphicsLayer()
 
     BaseScreen(
+        modifier = Modifier
+            .drawWithContent {
+                graphicsLayer.record {
+                    this@drawWithContent.drawContent()
+                }
+                drawLayer(graphicsLayer)
+            },
         drawerContent = {
             DrawerSheet(
                 chapters = state.chapters,
@@ -158,11 +164,7 @@ private fun PoemOfDayScreen(
                                     Icons.Outlined.FavoriteBorder
                                 },
                                 contentDescription = "Toggle favourite",
-                                tint = if (state.poem.isFavourite) {
-                                    LocalColors.current.onPrimary
-                                } else {
-                                    LocalColors.current.onPrimary.copy(alpha = 0.6f)
-                                }
+                                tint = LocalColors.current.onPrimary
                             )
                         }
                     }
@@ -191,13 +193,7 @@ private fun PoemOfDayScreen(
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .weight(1f)
-                            .drawWithContent {
-                                graphicsLayer.record {
-                                    this@drawWithContent.drawContent()
-                                }
-                                drawLayer(graphicsLayer)
-                            },
+                            .weight(1f),
                         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
                         colors = CardDefaults.cardColors(
                             containerColor = LocalColors.current.surface

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -1,8 +1,8 @@
 package com.firdavs.persianliterature.poem_of_day
 
-import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -35,6 +37,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -45,6 +48,7 @@ import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
 import com.firdavs.persianliterature.ui.kit.BaseScreen
 import com.firdavs.persianliterature.ui.kit.H2Text
 import com.firdavs.persianliterature.ui.kit.H3Text
+import com.firdavs.persianliterature.ui.kit.H5Text
 import com.firdavs.persianliterature.ui.kit.T1Text
 import com.firdavs.persianliterature.ui.kit.T2Text
 import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
@@ -188,7 +192,7 @@ private fun PoemOfDayScreen(
                     LaunchedEffect(state.poem) {
                         scrollState.scrollTo(0)
                     }
-                    Card(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f)
@@ -197,36 +201,61 @@ private fun PoemOfDayScreen(
                                     this@drawWithContent.drawContent()
                                 }
                                 drawLayer(graphicsLayer)
-                            },
-                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-                        colors = CardDefaults.cardColors(
-                            containerColor = LocalColors.current.surface
-                        )
+                            }
                     ) {
-                        Column(
+                        Card(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .verticalScroll(scrollState)
-                                .padding(24.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
+                                .weight(1f),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = LocalColors.current.surface
+                            )
                         ) {
-                            H2Text(
-                                text = state.poem.title,
-                                textAlign = TextAlign.Center,
-                                color = LocalColors.current.primary
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .verticalScroll(scrollState)
+                                    .padding(24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                H2Text(
+                                    text = state.poem.title,
+                                    textAlign = TextAlign.Center,
+                                    color = LocalColors.current.primary
+                                )
+                                Spacer(modifier = Modifier.height(24.dp))
+                                T1Text(
+                                    text = state.poem.text,
+                                    textAlign = TextAlign.Center,
+                                    color = LocalColors.current.onSurface
+                                )
+                                Spacer(modifier = Modifier.height(24.dp))
+                                T2Text(
+                                    text = "— ${state.poem.author}",
+                                    textAlign = TextAlign.End,
+                                    color = LocalColors.current.onSurfaceVariant,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        }
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(LocalColors.current.primary)
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
+                        ) {
+                            Image(
+                                painter = painterResource(id = UiR.drawable.ic_app_icon),
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp)
                             )
-                            Spacer(modifier = Modifier.height(24.dp))
-                            T1Text(
-                                text = state.poem.text,
-                                textAlign = TextAlign.Center,
-                                color = LocalColors.current.onSurface
-                            )
-                            Spacer(modifier = Modifier.height(24.dp))
-                            T2Text(
-                                text = "— ${state.poem.author}",
-                                textAlign = TextAlign.End,
-                                color = LocalColors.current.onSurfaceVariant,
-                                modifier = Modifier.fillMaxWidth()
+                            Spacer(modifier = Modifier.width(8.dp))
+                            H5Text(
+                                text = stringResource(UiR.string.drawer_title),
+                                color = LocalColors.current.onPrimary
                             )
                         }
                     }

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -1,8 +1,8 @@
 package com.firdavs.persianliterature.poem_of_day
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -37,7 +35,6 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -48,7 +45,6 @@ import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
 import com.firdavs.persianliterature.ui.kit.BaseScreen
 import com.firdavs.persianliterature.ui.kit.H2Text
 import com.firdavs.persianliterature.ui.kit.H3Text
-import com.firdavs.persianliterature.ui.kit.H5Text
 import com.firdavs.persianliterature.ui.kit.T1Text
 import com.firdavs.persianliterature.ui.kit.T2Text
 import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
@@ -192,7 +188,7 @@ private fun PoemOfDayScreen(
                     LaunchedEffect(state.poem) {
                         scrollState.scrollTo(0)
                     }
-                    Column(
+                    Card(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f)
@@ -201,61 +197,36 @@ private fun PoemOfDayScreen(
                                     this@drawWithContent.drawContent()
                                 }
                                 drawLayer(graphicsLayer)
-                            }
+                            },
+                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = LocalColors.current.surface
+                        )
                     ) {
-                        Card(
+                        Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .weight(1f),
-                            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-                            colors = CardDefaults.cardColors(
-                                containerColor = LocalColors.current.surface
-                            )
+                                .verticalScroll(scrollState)
+                                .padding(24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .verticalScroll(scrollState)
-                                    .padding(24.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                H2Text(
-                                    text = state.poem.title,
-                                    textAlign = TextAlign.Center,
-                                    color = LocalColors.current.primary
-                                )
-                                Spacer(modifier = Modifier.height(24.dp))
-                                T1Text(
-                                    text = state.poem.text,
-                                    textAlign = TextAlign.Center,
-                                    color = LocalColors.current.onSurface
-                                )
-                                Spacer(modifier = Modifier.height(24.dp))
-                                T2Text(
-                                    text = "— ${state.poem.author}",
-                                    textAlign = TextAlign.End,
-                                    color = LocalColors.current.onSurfaceVariant,
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                            }
-                        }
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(LocalColors.current.primary)
-                                .padding(horizontal = 16.dp, vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center
-                        ) {
-                            Image(
-                                painter = painterResource(id = UiR.drawable.ic_app_icon),
-                                contentDescription = null,
-                                modifier = Modifier.size(24.dp)
+                            H2Text(
+                                text = state.poem.title,
+                                textAlign = TextAlign.Center,
+                                color = LocalColors.current.primary
                             )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            H5Text(
-                                text = stringResource(UiR.string.drawer_title),
-                                color = LocalColors.current.onPrimary
+                            Spacer(modifier = Modifier.height(24.dp))
+                            T1Text(
+                                text = state.poem.text,
+                                textAlign = TextAlign.Center,
+                                color = LocalColors.current.onSurface
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            T2Text(
+                                text = "— ${state.poem.author}",
+                                textAlign = TextAlign.End,
+                                color = LocalColors.current.onSurfaceVariant,
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
                     }

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -2,6 +2,7 @@ package com.firdavs.persianliterature.poem_of_day
 
 import android.content.Intent
 import android.graphics.Bitmap
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -127,25 +128,34 @@ private fun PoemOfDayScreen(
                         IconButton(
                             onClick = {
                                 coroutineScope.launch {
-                                    val bitmap = graphicsLayer.toImageBitmap().asAndroidBitmap()
-                                    withContext(Dispatchers.IO) {
+                                    try {
+                                        val bitmap = graphicsLayer.toImageBitmap().asAndroidBitmap()
                                         val file = File(context.cacheDir, "poem_of_day.png")
-                                        file.outputStream().use { out ->
-                                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                                        withContext(Dispatchers.IO) {
+                                            file.outputStream().use { out ->
+                                                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                                            }
+                                        }
+                                        val uri = FileProvider.getUriForFile(
+                                            context,
+                                            "${context.packageName}.fileprovider",
+                                            file
+                                        )
+                                        val intent = Intent(Intent.ACTION_SEND).apply {
+                                            type = "image/png"
+                                            putExtra(Intent.EXTRA_STREAM, uri)
+                                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        }
+                                        context.startActivity(Intent.createChooser(intent, null))
+                                    } catch (e: Exception) {
+                                        withContext(Dispatchers.Main) {
+                                            Toast.makeText(
+                                                context,
+                                                context.getString(R.string.share_poem_error),
+                                                Toast.LENGTH_SHORT
+                                            ).show()
                                         }
                                     }
-                                    val file = File(context.cacheDir, "poem_of_day.png")
-                                    val uri = FileProvider.getUriForFile(
-                                        context,
-                                        "${context.packageName}.fileprovider",
-                                        file
-                                    )
-                                    val intent = Intent(Intent.ACTION_SEND).apply {
-                                        type = "image/png"
-                                        putExtra(Intent.EXTRA_STREAM, uri)
-                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                    }
-                                    context.startActivity(Intent.createChooser(intent, null))
                                 }
                             }
                         ) {

--- a/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
+++ b/poem_of_day/src/main/java/com/firdavs/persianliterature/poem_of_day/PoemOfDayScreen.kt
@@ -1,5 +1,8 @@
 package com.firdavs.persianliterature.poem_of_day
 
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -23,12 +27,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
 import com.firdavs.persianliterature.core.model.Chapter
 import com.firdavs.persianliterature.ui.kit.BaseEntryPoint
 import com.firdavs.persianliterature.ui.kit.BaseScreen
@@ -40,7 +51,10 @@ import com.firdavs.persianliterature.ui.kit.components.DrawerSheet
 import com.firdavs.persianliterature.ui.kit.components.buttons.PrimaryButton
 import com.firdavs.persianliterature.ui.kit.theme.LocalColors
 import com.firdavs.persianliterature.ui.kit.theme.stringResource
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
 import com.firdavs.persianliterature.core.R as UiR
 
 @Composable
@@ -67,6 +81,9 @@ private fun PoemOfDayScreen(
     onPreviousPoemClick: () -> Unit,
     onToggleFavourite: () -> Unit
 ) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val graphicsLayer = rememberGraphicsLayer()
 
     BaseScreen(
         drawerContent = {
@@ -98,23 +115,56 @@ private fun PoemOfDayScreen(
                     overflow = TextOverflow.Ellipsis
                 )
                 if (state.poem != null) {
-                    IconButton(
-                        modifier = Modifier.align(Alignment.CenterEnd),
-                        onClick = onToggleFavourite
+                    Row(
+                        modifier = Modifier.align(Alignment.CenterEnd)
                     ) {
-                        Icon(
-                            imageVector = if (state.poem.isFavourite) {
-                                Icons.Filled.Favorite
-                            } else {
-                                Icons.Outlined.FavoriteBorder
-                            },
-                            contentDescription = "Toggle favourite",
-                            tint = if (state.poem.isFavourite) {
-                                LocalColors.current.onPrimary
-                            } else {
-                                LocalColors.current.onPrimary.copy(alpha = 0.6f)
+                        IconButton(
+                            onClick = {
+                                coroutineScope.launch {
+                                    val bitmap = graphicsLayer.toImageBitmap().asAndroidBitmap()
+                                    withContext(Dispatchers.IO) {
+                                        val file = File(context.cacheDir, "poem_of_day.png")
+                                        file.outputStream().use { out ->
+                                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                                        }
+                                    }
+                                    val file = File(context.cacheDir, "poem_of_day.png")
+                                    val uri = FileProvider.getUriForFile(
+                                        context,
+                                        "${context.packageName}.fileprovider",
+                                        file
+                                    )
+                                    val intent = Intent(Intent.ACTION_SEND).apply {
+                                        type = "image/png"
+                                        putExtra(Intent.EXTRA_STREAM, uri)
+                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    }
+                                    context.startActivity(Intent.createChooser(intent, null))
+                                }
                             }
-                        )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Share,
+                                contentDescription = stringResource(R.string.share_poem)
+                            )
+                        }
+                        IconButton(
+                            onClick = onToggleFavourite
+                        ) {
+                            Icon(
+                                imageVector = if (state.poem.isFavourite) {
+                                    Icons.Filled.Favorite
+                                } else {
+                                    Icons.Outlined.FavoriteBorder
+                                },
+                                contentDescription = "Toggle favourite",
+                                tint = if (state.poem.isFavourite) {
+                                    LocalColors.current.onPrimary
+                                } else {
+                                    LocalColors.current.onPrimary.copy(alpha = 0.6f)
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -141,7 +191,13 @@ private fun PoemOfDayScreen(
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .weight(1f),
+                            .weight(1f)
+                            .drawWithContent {
+                                graphicsLayer.record {
+                                    this@drawWithContent.drawContent()
+                                }
+                                drawLayer(graphicsLayer)
+                            },
                         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
                         colors = CardDefaults.cardColors(
                             containerColor = LocalColors.current.surface

--- a/poem_of_day/src/main/res/values-ru/strings.xml
+++ b/poem_of_day/src/main/res/values-ru/strings.xml
@@ -4,4 +4,5 @@
     <string name="new_poem">Новый стих</string>
     <string name="previous_poem">Предыдущий стих</string>
     <string name="no_poems_available">Стихи пока недоступны</string>
+    <string name="share_poem">Поделиться стихом</string>
 </resources>

--- a/poem_of_day/src/main/res/values-ru/strings.xml
+++ b/poem_of_day/src/main/res/values-ru/strings.xml
@@ -5,4 +5,5 @@
     <string name="previous_poem">Предыдущий стих</string>
     <string name="no_poems_available">Стихи пока недоступны</string>
     <string name="share_poem">Поделиться стихом</string>
+    <string name="share_poem_error">Не удалось поделиться стихом</string>
 </resources>

--- a/poem_of_day/src/main/res/values-tg/strings.xml
+++ b/poem_of_day/src/main/res/values-tg/strings.xml
@@ -5,4 +5,5 @@
     <string name="previous_poem">Шеъри пешин</string>
     <string name="no_poems_available">Шеърҳо ҳанӯз дастрас нестанд</string>
     <string name="share_poem">Мубодилаи шеър</string>
+    <string name="share_poem_error">Мубодилаи шеър номуваффақ буд</string>
 </resources>

--- a/poem_of_day/src/main/res/values-tg/strings.xml
+++ b/poem_of_day/src/main/res/values-tg/strings.xml
@@ -5,5 +5,5 @@
     <string name="previous_poem">Шеъри пешин</string>
     <string name="no_poems_available">Шеърҳо ҳанӯз дастрас нестанд</string>
     <string name="share_poem">Мубодилаи шеър</string>
-    <string name="share_poem_error">Мубодилаи шеър номуваффақ буд</string>
+    <string name="share_poem_error">Мубодилаи шеър ноком шуд</string>
 </resources>

--- a/poem_of_day/src/main/res/values-tg/strings.xml
+++ b/poem_of_day/src/main/res/values-tg/strings.xml
@@ -4,4 +4,5 @@
     <string name="new_poem">Шеъри нав</string>
     <string name="previous_poem">Шеъри пешин</string>
     <string name="no_poems_available">Шеърҳо ҳанӯз дастрас нестанд</string>
+    <string name="share_poem">Мубодилаи шеър</string>
 </resources>

--- a/poem_of_day/src/main/res/values/strings.xml
+++ b/poem_of_day/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="previous_poem">Previous Poem</string>
     <string name="no_poems_available">No poems available yet</string>
     <string name="share_poem">Share poem</string>
+    <string name="share_poem_error">Failed to share poem</string>
 </resources>

--- a/poem_of_day/src/main/res/values/strings.xml
+++ b/poem_of_day/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="new_poem">New Poem</string>
     <string name="previous_poem">Previous Poem</string>
     <string name="no_poems_available">No poems available yet</string>
+    <string name="share_poem">Share poem</string>
 </resources>


### PR DESCRIPTION
Adds a share icon to the PoemOfDay top bar that captures the poem card as a screenshot and shares it via Android's share sheet.

Closes #74

Generated with [Claude Code](https://claude.ai/code)