### PR TITLE
Save reading progress in WorkDetailsScreen

### DIFF
--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -212,7 +212,6 @@ fun WorkDetailsScreen(
                                 modifier = Modifier
                                     .fillMaxSize(),
                                 source = PdfSource.LocalFile(workFile),
-                                scrollTo = state.savedPage,
                                 onPageChanged = { page, _ -> onPageChanged(page) }
                             )
                             IconButton(

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsScreen.kt
@@ -91,7 +91,8 @@ fun WorkDetailsEntryPoint(
             onPauseAudio = viewModel::onPauseAudio,
             onSeekTo = viewModel::onSeekTo,
             onSkipBackward = viewModel::onSkipBackward,
-            onSkipForward = viewModel::onSkipForward
+            onSkipForward = viewModel::onSkipForward,
+            onPageChanged = viewModel::onPageChanged
         )
     }
 }
@@ -106,7 +107,8 @@ fun WorkDetailsScreen(
     onPauseAudio: () -> Unit = {},
     onSeekTo: (Long) -> Unit = {},
     onSkipBackward: () -> Unit = {},
-    onSkipForward: () -> Unit = {}
+    onSkipForward: () -> Unit = {},
+    onPageChanged: (Int) -> Unit = {}
 ) {
     var isBarsVisible by remember { mutableStateOf(true) }
 
@@ -209,7 +211,9 @@ fun WorkDetailsScreen(
                             PdfRendererViewCompose(
                                 modifier = Modifier
                                     .fillMaxSize(),
-                                source = PdfSource.LocalFile(workFile)
+                                source = PdfSource.LocalFile(workFile),
+                                scrollTo = state.savedPage,
+                                onPageChanged = { page, _ -> onPageChanged(page) }
                             )
                             IconButton(
                                 modifier = Modifier

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsUiState.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsUiState.kt
@@ -15,5 +15,6 @@ data class WorkDetailsUiState(
     val playbackState: PlaybackState = PlaybackState(),
     val currentlyPreparedAudioPath: String? = null,
     val hasCompletedInitialPreparation: Boolean = false,
-    val showAudioControlToast: Boolean = false
+    val showAudioControlToast: Boolean = false,
+    val savedPage: Int = 0
 ) : UiState()

--- a/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsViewModel.kt
+++ b/author_ui/src/main/java/com/firdavs/persianliterature/author/ui/work_details/WorkDetailsViewModel.kt
@@ -2,6 +2,7 @@ package com.firdavs.persianliterature.author.ui.work_details
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.lifecycle.viewModelScope
 import com.firdavs.persianliterature.audio.api.player.PlaybackState
 import com.firdavs.persianliterature.audio.api.service.AudioServiceController
@@ -29,6 +30,8 @@ class WorkDetailsViewModel(
 ) : BaseViewModel<WorkDetailsUiState>(WorkDetailsUiState(null)) {
     private val downloadPdfScope = CoroutineScope(Job() + Dispatchers.IO)
     private var firstAudioPlay = true
+    private val readingProgressPrefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_READING_PROGRESS, Context.MODE_PRIVATE)
 
     init {
         audioServiceController.connect()
@@ -42,11 +45,17 @@ class WorkDetailsViewModel(
         audioServiceController.syncPlaybackState()
     }
 
+    fun onPageChanged(page: Int) {
+        readingProgressPrefs.edit().putInt(pageKey(id), page).apply()
+        post { it.copy(savedPage = page) }
+    }
+
     private fun observeWork() {
         viewModelScope.launch {
             worksRepository.getWork(id).collect { work ->
+                val savedPage = readingProgressPrefs.getInt(pageKey(id), 0)
                 post {
-                    it.copy(work = work)
+                    it.copy(work = work, savedPage = savedPage)
                 }
                 // Handle PDF download (existing logic)
                 work.fileUrl?.let {
@@ -229,5 +238,7 @@ class WorkDetailsViewModel(
 
     companion object {
         private const val SKIP_DURATION_MS = 10000L
+        private const val PREFS_READING_PROGRESS = "reading_progress_preferences"
+        private fun pageKey(workId: String) = "page_$workId"
     }
 }


### PR DESCRIPTION
Persist the current PDF page to SharedPreferences keyed by work ID so that when the user returns to a work they left mid-read, the viewer reopens on the last page they were on.

Closes #81

Generated with [Claude Code](https://claude.ai/code)